### PR TITLE
CI: minimum rust version is 1.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                rust: [1.38.0, stable, nightly]
+                rust: [1.40.0, stable, nightly]
         steps:
         - uses: actions/checkout@v2
         - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
`serde_with` requires this version.

Signed-off-by: Petre Eftime <epetre@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
