### PR TITLE
sign: Allow serde to deserialize tagged values

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -6,7 +6,7 @@ use openssl::hash::{hash, MessageDigest};
 use openssl::nid::Nid;
 use openssl::pkey::PKeyRef;
 use openssl::pkey::{Private, Public};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_bytes::ByteBuf;
 use serde_cbor::Error as CborError;
 use serde_cbor::Value as CborValue;
@@ -237,7 +237,7 @@ impl SigStructure {
 ///   the spec and the only way to achieve this is to add the token at the
 ///   start of the serialized object, since the serde_cbor library doesn't
 ///   support custom tags.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct COSESign1(
     /// protected: empty_or_serialized_map,
     ByteBuf,
@@ -250,6 +250,60 @@ pub struct COSESign1(
     /// signature: bstr
     ByteBuf,
 );
+
+impl<'de> Deserialize<'de> for COSESign1 {
+    fn deserialize<D>(deserializer: D) -> Result<COSESign1, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, SeqAccess, Visitor};
+        use std::fmt;
+
+        struct COSESign1Visitor;
+
+        impl<'de> Visitor<'de> for COSESign1Visitor {
+            type Value = COSESign1;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a possibly tagged COSESign1 structure")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<COSESign1, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                // This is the untagged version
+                let protected = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("protected")),
+                };
+                let header_map = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("header_map")),
+                };
+                let payload = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("payload")),
+                };
+                let signature = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("signature")),
+                };
+                Ok(COSESign1(protected, header_map, payload, signature))
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<COSESign1, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                // This is the tagged version: we ignore the tag part, and just go into it
+                deserializer.deserialize_seq(COSESign1Visitor)
+            }
+        }
+
+        deserializer.deserialize_any(COSESign1Visitor)
+    }
+}
 
 impl COSESign1 {
     /// Follows the recommandations put in place by the RFC and doesn't deal with potential
@@ -830,6 +884,24 @@ mod tests {
         // Tag 6.18 should be present
         assert_eq!(tagged_bytes[0], 6 << 5 | 18);
         let cose_doc2 = COSESign1::from_bytes(&tagged_bytes).unwrap();
+
+        assert_eq!(
+            cose_doc1.get_payload(None).unwrap(),
+            cose_doc2.get_payload(Some(&ec_public)).unwrap()
+        );
+    }
+
+    #[test]
+    fn cose_sign1_ec256_text_tagged_serde() {
+        let (ec_private, ec_public) = generate_ec256_test_key();
+        let mut map = HeaderMap::new();
+        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+        let cose_doc1 = COSESign1::new(TEXT, &map, &ec_private).unwrap();
+        let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
+        // Tag 6.18 should be present
+        assert_eq!(tagged_bytes[0], 6 << 5 | 18);
+        let cose_doc2: COSESign1 = serde_cbor::from_slice(&tagged_bytes).unwrap();
 
         assert_eq!(
             cose_doc1.get_payload(None).unwrap(),


### PR DESCRIPTION
Add the capability to use plain `serde_cbor::from_slice` to read tagged
`COSESign1` objects.
This manually implements Deserialize so that if we hit the Tagged value
(a newtype struct), it doesn't crash, and just returns the inner value.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Apache License Version 2.0, as specified in the LICENSE file of this repository.