### PR TITLE
sign: Allow access to unprotected header

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -510,6 +510,11 @@ impl COSESign1 {
         }
         Ok(self.2.to_vec())
     }
+
+    /// This gets the `unprotected` headers from the document.
+    pub fn get_unprotected(&self) -> &HeaderMap {
+        &self.1
+    }
 }
 
 #[cfg(test)]
@@ -855,6 +860,11 @@ mod tests {
         assert_eq!(
             cose_doc1.get_payload(None).unwrap(),
             cose_doc2.get_payload(Some(&ec_public)).unwrap()
+        );
+        assert!(!cose_doc2.get_unprotected().is_empty(),);
+        assert_eq!(
+            cose_doc2.get_unprotected().get(&CborValue::Integer(4)),
+            Some(&CborValue::Bytes(b"11".to_vec())),
         );
     }
 


### PR DESCRIPTION
Adds a function that returns the unprotected headermap, so applications
can use that if they want.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Apache License Version 2.0, as specified in the LICENSE file of this repository.