### PR TITLE
Fix clippy issues on rust 1.51

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
+// TODO: in 0.3.0 provide transitional type names and deprecate the old ones.
+#![allow(clippy::upper_case_acronyms)]
 
 //! This library aims to provide safe Rust implementations for COSE, using
 //! serde and serde_cbor as an encoding layer and OpenSSL as the base

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -62,13 +62,13 @@ pub enum SignatureAlgorithm {
     ES512 = -36,
 }
 
-impl Into<HeaderMap> for SignatureAlgorithm {
-    fn into(self) -> HeaderMap {
+impl From<SignatureAlgorithm> for HeaderMap {
+    fn from(sig_alg: SignatureAlgorithm) -> Self {
         // Convenience method for creating the map that would go into the signature structures
         // Can be appended into a larger HeaderMap
         // `1` is the index defined in the spec for Algorithm
         let mut map = HeaderMap::new();
-        map.insert(1.into(), (self as i8).into());
+        map.insert(1.into(), (sig_alg as i8).into());
         map
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -481,9 +481,8 @@ impl COSESign1 {
         let s = BigNum::from_slice(&bytes_s).map_err(COSEError::SignatureError)?;
 
         let sig = EcdsaSig::from_private_components(r, s).map_err(COSEError::SignatureError)?;
-        Ok(sig
-            .verify(&struct_digest, &key)
-            .map_err(COSEError::SignatureError)?)
+        sig.verify(&struct_digest, &key)
+            .map_err(COSEError::SignatureError)
     }
 
     /// This gets the `payload` and `protected` data of the document.


### PR DESCRIPTION
Fix a couple of clippy issues preventing builds on Rust 1.51


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
