### PR TITLE
Fix running "/bin/sh: ...: not found" error with MUSL enviroment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_cbor = { version="0.11", features = ["tags"] }
 serde_repr = "0.1"
 serde_bytes = "0.11"
 serde_with = "1.5"
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-nitro-enclaves-cose/issues/18

*Description of changes:*
Add "vendored" feature for openssl dependency:
> If the vendored Cargo feature is enabled, the openssl-src crate will be used to compile and statically link to a copy of OpenSSL. 
Here is a detailed description of the "vendored" feature: https://docs.rs/openssl/0.10.34/openssl/index.html#vendored
