### PR TITLE
Do not pull in serde_with_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "This library aims to provide a safe Rust implementation of COSE, 
 serde_cbor = { version="0.11", features = ["tags"] }
 serde_repr = "0.1"
 serde_bytes = "0.11"
-serde_with = "1.5"
+serde_with = { version = "1.5", default_features = false }
 openssl = "0.10"
 
 [dependencies.serde]


### PR DESCRIPTION
This patch disables the default features for serde_with, which pulls in
its macros feature.
This expands the dependencies farther than we need, since we don't use
the macros at all.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Apache License Version 2.0, as specified in the LICENSE file of this repository.
