### PR TITLE
Abstract all crypto implementation (includes #21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                rust: [1.40.0, stable, nightly]
+                rust: [1.46.0, stable, nightly]
         steps:
         - uses: actions/checkout@v2
         - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ openssl = "0.10"
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
+
+[features]
+default = ["key_openssl_pkey"]
+key_openssl_pkey = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,13 @@ serde_cbor = { version="0.11", features = ["tags"] }
 serde_repr = "0.1"
 serde_bytes = "0.11"
 serde_with = "1.5"
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 
 [dependencies.serde]
 version = "1.0"
 features = ["derive"]
 
 [features]
-default = ["key_openssl_pkey"]
-key_openssl_pkey = []
+default = ["crypto_openssl", "key_openssl_pkey"]
+key_openssl_pkey = ["openssl"]
+crypto_openssl = ["openssl"]

--- a/src/crypto/crypto_openssl.rs
+++ b/src/crypto/crypto_openssl.rs
@@ -1,0 +1,72 @@
+//! OpenSSL crypto implementation
+
+use openssl::{hash::MessageDigest, symm::Cipher};
+
+use crate::{crypto::HashFunction, encrypt::COSEAlgorithm};
+
+/// The type of errors reported
+pub type CryptoError = openssl::error::ErrorStack;
+
+/// Compute a message digest (hash), given a hash function and data
+pub fn hash(hf: HashFunction, data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    openssl::hash::hash(hf.into(), data).map(|x| x.to_vec())
+}
+
+/// Convert a value from the internal HashFunction to openssl MessageDigest
+impl From<HashFunction> for MessageDigest {
+    fn from(hf: HashFunction) -> openssl::hash::MessageDigest {
+        match hf {
+            HashFunction::Sha256 => MessageDigest::sha256(),
+            HashFunction::Sha384 => MessageDigest::sha384(),
+            HashFunction::Sha512 => MessageDigest::sha512(),
+        }
+    }
+}
+
+impl From<COSEAlgorithm> for Cipher {
+    fn from(cc: COSEAlgorithm) -> Cipher {
+        match cc {
+            COSEAlgorithm::AesGcm96_128_128 => Cipher::aes_128_gcm(),
+            COSEAlgorithm::AesGcm96_128_192 => Cipher::aes_192_gcm(),
+            COSEAlgorithm::AesGcm96_128_256 => Cipher::aes_256_gcm(),
+        }
+    }
+}
+
+impl COSEAlgorithm {
+    pub(crate) fn encrypt(
+        &self,
+        key: &[u8],
+        aad: &[u8],
+        plaintext: &[u8],
+    ) -> Result<(Vec<u8>, Option<Vec<u8>>), CryptoError> {
+        let cipher = Cipher::from(*self);
+
+        let mut iv = vec![0; cipher.iv_len().unwrap()];
+        openssl::rand::rand_bytes(&mut iv)?;
+
+        let mut tag = vec![0; self.tag_size()];
+        let mut ciphertext =
+            openssl::symm::encrypt_aead(cipher, key, Some(&iv[..]), aad, plaintext, &mut tag)?;
+
+        ciphertext.append(&mut tag);
+
+        Ok((ciphertext, Some(iv)))
+    }
+
+    pub(crate) fn decrypt(
+        &self,
+        key: &[u8],
+        aad: &[u8],
+        iv: Option<&[u8]>,
+        ciphertext: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let cipher = Cipher::from(*self);
+
+        let (ciphertext, tag) = ciphertext.split_at(ciphertext.len() - self.tag_size());
+
+        let plaintext = openssl::symm::decrypt_aead(cipher, key, iv, aad, ciphertext, tag)?;
+
+        Ok(plaintext)
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,52 @@
+//! (Signing) cryptography abstraction
+
+use openssl::{hash::MessageDigest, nid::Nid};
+
+use crate::{error::CoseError, sign::SignatureAlgorithm};
+
+#[cfg(feature = "key_openssl_pkey")]
+mod openssl_pkey;
+
+/// A public key that can verify an existing signature
+pub trait SigningPublicKey {
+    /// This returns the signature algorithm and message digest to be used for this
+    /// public key.
+    fn get_parameters(&self) -> Result<(SignatureAlgorithm, MessageDigest), CoseError>;
+
+    /// Given a digest and a signature, returns a boolean whether the signature
+    /// was valid.
+    fn verify(&self, digest: &[u8], signature: &[u8]) -> Result<bool, CoseError>;
+}
+
+/// Follows the recommandations put in place by the RFC and doesn't deal with potential
+/// mismatches: https://tools.ietf.org/html/rfc8152#section-8.1.
+pub fn ec_curve_to_parameters(
+    curve_name: Nid,
+) -> Result<(SignatureAlgorithm, MessageDigest, usize), CoseError> {
+    let sig_alg = match curve_name {
+        // Recommended to use with SHA256
+        Nid::X9_62_PRIME256V1 => SignatureAlgorithm::ES256,
+        // Recommended to use with SHA384
+        Nid::SECP384R1 => SignatureAlgorithm::ES384,
+        // Recommended to use with SHA512
+        Nid::SECP521R1 => SignatureAlgorithm::ES512,
+        _ => {
+            return Err(CoseError::UnsupportedError(format!(
+                "Curve name {:?} is not supported",
+                curve_name
+            )))
+        }
+    };
+
+    Ok((
+        sig_alg,
+        sig_alg.suggested_message_digest(),
+        sig_alg.key_length(),
+    ))
+}
+
+/// A private key that can produce new signatures
+pub trait SigningPrivateKey: SigningPublicKey {
+    /// Given a digest, returns a signature
+    fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError>;
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,9 +1,28 @@
-//! (Signing) cryptography abstraction
-
-use openssl::{hash::MessageDigest, nid::Nid};
+//! Cryptography abstraction
 
 use crate::{error::CoseError, sign::SignatureAlgorithm};
 
+/// Message digest functions
+#[derive(Debug, Copy, Clone)]
+pub enum HashFunction {
+    /// SHA256
+    Sha256,
+    /// SHA384
+    Sha384,
+    /// SHA512
+    Sha512,
+}
+
+// Switch between the different crypto algorithms
+#[cfg(feature = "crypto_openssl")]
+mod crypto_openssl;
+#[cfg(feature = "crypto_openssl")]
+pub use crypto_openssl::*;
+
+#[cfg(not(any(feature = "crypto_openssl")))]
+compile_error!("Please enable a crypto implementation");
+
+// Import the different shipped signing crypto
 #[cfg(feature = "key_openssl_pkey")]
 mod openssl_pkey;
 
@@ -11,38 +30,11 @@ mod openssl_pkey;
 pub trait SigningPublicKey {
     /// This returns the signature algorithm and message digest to be used for this
     /// public key.
-    fn get_parameters(&self) -> Result<(SignatureAlgorithm, MessageDigest), CoseError>;
+    fn get_parameters(&self) -> Result<(SignatureAlgorithm, HashFunction), CoseError>;
 
     /// Given a digest and a signature, returns a boolean whether the signature
     /// was valid.
     fn verify(&self, digest: &[u8], signature: &[u8]) -> Result<bool, CoseError>;
-}
-
-/// Follows the recommandations put in place by the RFC and doesn't deal with potential
-/// mismatches: https://tools.ietf.org/html/rfc8152#section-8.1.
-pub fn ec_curve_to_parameters(
-    curve_name: Nid,
-) -> Result<(SignatureAlgorithm, MessageDigest, usize), CoseError> {
-    let sig_alg = match curve_name {
-        // Recommended to use with SHA256
-        Nid::X9_62_PRIME256V1 => SignatureAlgorithm::ES256,
-        // Recommended to use with SHA384
-        Nid::SECP384R1 => SignatureAlgorithm::ES384,
-        // Recommended to use with SHA512
-        Nid::SECP521R1 => SignatureAlgorithm::ES512,
-        _ => {
-            return Err(CoseError::UnsupportedError(format!(
-                "Curve name {:?} is not supported",
-                curve_name
-            )))
-        }
-    };
-
-    Ok((
-        sig_alg,
-        sig_alg.suggested_message_digest(),
-        sig_alg.key_length(),
-    ))
 }
 
 /// A private key that can produce new signatures

--- a/src/crypto/openssl_pkey.rs
+++ b/src/crypto/openssl_pkey.rs
@@ -1,0 +1,121 @@
+//! OpenSSL PKey(Ref) implementation for cryptography
+
+use openssl::{
+    bn::BigNum,
+    ecdsa::EcdsaSig,
+    hash::MessageDigest,
+    pkey::{HasPrivate, HasPublic, PKey, PKeyRef},
+};
+
+use crate::{
+    crypto::{ec_curve_to_parameters, SigningPrivateKey, SigningPublicKey},
+    error::CoseError,
+    sign::SignatureAlgorithm,
+};
+
+impl<T> SigningPublicKey for PKey<T>
+where
+    T: HasPublic,
+{
+    fn get_parameters(&self) -> Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+        self.as_ref().get_parameters()
+    }
+
+    fn verify(&self, digest: &[u8], signature: &[u8]) -> Result<bool, CoseError> {
+        self.as_ref().verify(digest, signature)
+    }
+}
+
+impl<T> SigningPublicKey for PKeyRef<T>
+where
+    T: HasPublic,
+{
+    fn get_parameters(&self) -> Result<(SignatureAlgorithm, MessageDigest), CoseError> {
+        let curve_name = self
+            .ec_key()
+            .map_err(|_| CoseError::UnsupportedError("Non-EC keys are not supported".to_string()))?
+            .group()
+            .curve_name()
+            .ok_or_else(|| {
+                CoseError::UnsupportedError("Anonymous EC keys are not supported".to_string())
+            })?;
+
+        let curve_parameters = ec_curve_to_parameters(curve_name)?;
+
+        Ok((curve_parameters.0, curve_parameters.1))
+    }
+
+    fn verify(&self, digest: &[u8], signature: &[u8]) -> Result<bool, CoseError> {
+        let key = self.ec_key().map_err(|_| {
+            CoseError::UnsupportedError("Non-EC keys are not yet supported".to_string())
+        })?;
+
+        let curve_name = key.group().curve_name().ok_or_else(|| {
+            CoseError::UnsupportedError("Anonymous EC keys are not supported".to_string())
+        })?;
+
+        let (_, _, key_length) = ec_curve_to_parameters(curve_name)?;
+
+        // Recover the R and S factors from the signature contained in the object
+        let (bytes_r, bytes_s) = signature.split_at(key_length);
+
+        let r = BigNum::from_slice(&bytes_r).map_err(CoseError::SignatureError)?;
+        let s = BigNum::from_slice(&bytes_s).map_err(CoseError::SignatureError)?;
+
+        let sig = EcdsaSig::from_private_components(r, s).map_err(CoseError::SignatureError)?;
+        sig.verify(digest, &key).map_err(CoseError::SignatureError)
+    }
+}
+
+impl<T> SigningPrivateKey for PKey<T>
+where
+    T: HasPrivate,
+{
+    fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError> {
+        self.as_ref().sign(digest)
+    }
+}
+
+impl<T> SigningPrivateKey for PKeyRef<T>
+where
+    T: HasPrivate,
+{
+    fn sign(&self, digest: &[u8]) -> Result<Vec<u8>, CoseError> {
+        let key = self.ec_key().map_err(|_| {
+            CoseError::UnsupportedError("Non-EC keys are not yet supported".to_string())
+        })?;
+
+        let curve_name = key.group().curve_name().ok_or_else(|| {
+            CoseError::UnsupportedError("Anonymous EC keys are not supported".to_string())
+        })?;
+
+        let (_, _, key_length) = ec_curve_to_parameters(curve_name)?;
+
+        // The spec defines the signature as:
+        // Signature = I2OSP(R, n) | I2OSP(S, n), where n = ceiling(key_length / 8)
+        // The Signer interface doesn't provide this, so this will use EcdsaSig interface instead
+        // and concatenate R and S.
+        // See https://tools.ietf.org/html/rfc8017#section-4.1 for details.
+        let signature = EcdsaSig::sign(digest, &key).map_err(CoseError::SignatureError)?;
+        let bytes_r = signature.r().to_vec();
+        let bytes_s = signature.s().to_vec();
+
+        // These should *never* exceed ceiling(key_length / 8)
+        assert!(bytes_r.len() <= key_length);
+        assert!(bytes_s.len() <= key_length);
+
+        let mut signature_bytes = vec![0u8; key_length * 2];
+
+        // This is big-endian encoding so padding might be added at the start if the factor is
+        // too short.
+        let offset_copy = key_length - bytes_r.len();
+        signature_bytes[offset_copy..offset_copy + bytes_r.len()].copy_from_slice(&bytes_r);
+
+        // This is big-endian encoding so padding might be added at the start if the factor is
+        // too short.
+        let offset_copy = key_length - bytes_s.len() + key_length;
+        signature_bytes[offset_copy..offset_copy + bytes_s.len()].copy_from_slice(&bytes_s);
+
+        Ok(signature_bytes)
+    }
+}

--- a/src/crypto/openssl_pkey.rs
+++ b/src/crypto/openssl_pkey.rs
@@ -59,8 +59,8 @@ where
         // Recover the R and S factors from the signature contained in the object
         let (bytes_r, bytes_s) = signature.split_at(key_length);
 
-        let r = BigNum::from_slice(&bytes_r).map_err(CoseError::SignatureError)?;
-        let s = BigNum::from_slice(&bytes_s).map_err(CoseError::SignatureError)?;
+        let r = BigNum::from_slice(bytes_r).map_err(CoseError::SignatureError)?;
+        let s = BigNum::from_slice(bytes_s).map_err(CoseError::SignatureError)?;
 
         let sig = EcdsaSig::from_private_components(r, s).map_err(CoseError::SignatureError)?;
         sig.verify(digest, &key).map_err(CoseError::SignatureError)

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -320,12 +320,12 @@ impl CoseEncrypt0 {
         let payload = decrypt_aead(
             cose_alg.openssl_cipher(),
             key,
-            Some(&iv),
+            Some(iv),
             &enc_structure
                 .as_bytes()
                 .map_err(CoseError::SerializationError)?,
             ciphertext,
-            &tag,
+            tag,
         )
         .map_err(CoseError::EncryptionError)?;
 

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,7 +1,5 @@
 //! COSE Encryption
 
-use openssl::rand::rand_bytes;
-use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
 use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 use serde_cbor::Error as CborError;
@@ -32,7 +30,8 @@ impl CipherConfiguration {
     }
 }
 
-enum COSEAlgorithm {
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum COSEAlgorithm {
     /// AES-GCM mode w/ 128-bit key, 128-bit tag
     AesGcm96_128_128,
     /// AES-GCM mode w/ 192-bit key, 128-bit tag
@@ -42,6 +41,15 @@ enum COSEAlgorithm {
 }
 
 impl COSEAlgorithm {
+    // Returns the tag size for the given algorithm in bytes.
+    pub(crate) fn tag_size(&self) -> usize {
+        match self {
+            COSEAlgorithm::AesGcm96_128_128 => 16,
+            COSEAlgorithm::AesGcm96_128_192 => 16,
+            COSEAlgorithm::AesGcm96_128_256 => 16,
+        }
+    }
+
     fn value(&self) -> usize {
         match self {
             COSEAlgorithm::AesGcm96_128_128 => 1,
@@ -57,23 +65,6 @@ impl COSEAlgorithm {
             3 => COSEAlgorithm::AesGcm96_128_256,
             _ => return None,
         })
-    }
-
-    // Returns the tag size for the given algorithm in bytes.
-    fn tag_size(&self) -> usize {
-        match self {
-            COSEAlgorithm::AesGcm96_128_128 => 16,
-            COSEAlgorithm::AesGcm96_128_192 => 16,
-            COSEAlgorithm::AesGcm96_128_256 => 16,
-        }
-    }
-
-    fn openssl_cipher(&self) -> Cipher {
-        match self {
-            COSEAlgorithm::AesGcm96_128_128 => Cipher::aes_128_gcm(),
-            COSEAlgorithm::AesGcm96_128_192 => Cipher::aes_192_gcm(),
-            COSEAlgorithm::AesGcm96_128_256 => Cipher::aes_256_gcm(),
-        }
     }
 }
 
@@ -234,15 +225,10 @@ impl CoseEncrypt0 {
                 ))
             }
         };
-        let cipher = cose_alg.openssl_cipher();
-        let mut iv = vec![0; cipher.iv_len().unwrap()];
-        rand_bytes(&mut iv).unwrap();
 
         let cose_alg_value = cose_alg.value();
         let mut protected = HeaderMap::new();
         protected.insert(KTY.into(), CborValue::Integer(cose_alg_value as i128));
-        let mut unprotected = HeaderMap::new();
-        unprotected.insert(IV.into(), CborValue::Bytes(iv.to_owned()));
 
         let protected_bytes =
             map_to_empty_or_serialized(&protected).map_err(CoseError::SerializationError)?;
@@ -250,20 +236,18 @@ impl CoseEncrypt0 {
         let enc_structure =
             EncStructure::new_encrypt0(&protected_bytes).map_err(CoseError::SerializationError)?;
 
-        let mut tag = vec![0; cose_alg.tag_size()];
-        let mut ciphertext = encrypt_aead(
-            cipher,
-            key,
-            Some(&iv[..]),
-            &enc_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
-            payload,
-            &mut tag,
-        )
-        .map_err(CoseError::EncryptionError)?;
+        let aad = &enc_structure
+            .as_bytes()
+            .map_err(CoseError::SerializationError)?;
 
-        ciphertext.append(&mut tag);
+        let (ciphertext, iv) = cose_alg
+            .encrypt(key, aad, payload)
+            .map_err(CoseError::EncryptionError)?;
+
+        let mut unprotected = HeaderMap::new();
+        if let Some(iv) = iv {
+            unprotected.insert(IV.into(), CborValue::Bytes(iv));
+        }
 
         Ok(CoseEncrypt0 {
             protected: ByteBuf::from(protected_bytes),
@@ -313,21 +297,13 @@ impl CoseEncrypt0 {
             }
         };
 
-        let (ciphertext, tag) = self
-            .ciphertext
-            .split_at(self.ciphertext.len() - cose_alg.tag_size());
+        let aad = &enc_structure
+            .as_bytes()
+            .map_err(CoseError::SerializationError)?;
 
-        let payload = decrypt_aead(
-            cose_alg.openssl_cipher(),
-            key,
-            Some(iv),
-            &enc_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
-            ciphertext,
-            tag,
-        )
-        .map_err(CoseError::EncryptionError)?;
+        let payload = cose_alg
+            .decrypt(key, aad, Some(iv), &self.ciphertext)
+            .map_err(CoseError::EncryptionError)?;
 
         Ok((protected, &self.unprotected, payload))
     }
@@ -413,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decrypt_unsupported_openssl_cipher() {
+    fn test_decrypt_unsupported_cipher() {
         let key = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F";
         let plaintext = b"\x12\x34\x56\x78\x90\x12\x34\x56\x12\x34\x56\x78\x90\x12\x34\x56";
         let mut cencrypt0 = CoseEncrypt0::new(plaintext, CipherConfiguration::Gcm, key).unwrap();

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -36,7 +36,7 @@ impl HeaderMap {
 
     /// Parses a slice of bytes into a HeaderMap, if possible.
     pub fn from_bytes(header_map: &[u8]) -> Result<Self, CborError> {
-        serde_cbor::from_slice(&header_map)
+        serde_cbor::from_slice(header_map)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! Currently only COSE Sign1 and COSE Encrypt0 are implemented.
 
+pub mod crypto;
 pub mod encrypt;
 pub mod error;
 pub mod header_map;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,17 +1,15 @@
 //! COSE Signing
 
-use openssl::bn::BigNum;
-use openssl::ecdsa::EcdsaSig;
+use std::str::FromStr;
+
 use openssl::hash::{hash, MessageDigest};
-use openssl::nid::Nid;
-use openssl::pkey::PKeyRef;
-use openssl::pkey::{Private, Public};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
 use serde_cbor::Error as CborError;
 use serde_cbor::Value as CborValue;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+use crate::crypto::{SigningPrivateKey, SigningPublicKey};
 use crate::error::CoseError;
 use crate::header_map::{map_to_empty_or_serialized, HeaderMap};
 
@@ -25,6 +23,52 @@ pub enum SignatureAlgorithm {
     ES384 = -35,
     /// ECDSA w/ SHA-512
     ES512 = -36,
+}
+
+impl SignatureAlgorithm {
+    pub(crate) fn key_length(&self) -> usize {
+        match self {
+            SignatureAlgorithm::ES256 => 32,
+            SignatureAlgorithm::ES384 => 48,
+            // Not a typo
+            SignatureAlgorithm::ES512 => 66,
+        }
+    }
+
+    pub(crate) fn suggested_message_digest(&self) -> MessageDigest {
+        match self {
+            SignatureAlgorithm::ES256 => MessageDigest::sha256(),
+            SignatureAlgorithm::ES384 => MessageDigest::sha384(),
+            SignatureAlgorithm::ES512 => MessageDigest::sha512(),
+        }
+    }
+}
+
+impl FromStr for SignatureAlgorithm {
+    type Err = CoseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ES256" => Ok(SignatureAlgorithm::ES256),
+            "ES384" => Ok(SignatureAlgorithm::ES384),
+            "ES512" => Ok(SignatureAlgorithm::ES512),
+            name => Err(CoseError::UnsupportedError(format!(
+                "Algorithm '{}' is not supported",
+                name
+            ))),
+        }
+    }
+}
+
+impl ToString for SignatureAlgorithm {
+    fn to_string(&self) -> String {
+        match self {
+            SignatureAlgorithm::ES256 => "ES256",
+            SignatureAlgorithm::ES384 => "ES384",
+            SignatureAlgorithm::ES512 => "ES512",
+        }
+        .to_string()
+    }
 }
 
 impl From<SignatureAlgorithm> for HeaderMap {
@@ -284,45 +328,15 @@ impl<'de> Deserialize<'de> for CoseSign1 {
 }
 
 impl CoseSign1 {
-    /// Follows the recommandations put in place by the RFC and doesn't deal with potential
-    /// mismatches: https://tools.ietf.org/html/rfc8152#section-8.1.
-    fn curve_to_parameters(
-        curve_name: Nid,
-    ) -> Result<(SignatureAlgorithm, MessageDigest, usize), CoseError> {
-        match curve_name {
-            // Recommended to use with SHA256
-            Nid::X9_62_PRIME256V1 => Ok((SignatureAlgorithm::ES256, MessageDigest::sha256(), 32)),
-            // Recommended to use with SHA384
-            Nid::SECP384R1 => Ok((SignatureAlgorithm::ES384, MessageDigest::sha384(), 48)),
-            // Recommended to use with SHA512
-            Nid::SECP521R1 => Ok((
-                SignatureAlgorithm::ES512,
-                MessageDigest::sha512(),
-                66, /* Not a typo */
-            )),
-            _ => Err(CoseError::UnsupportedError(format!(
-                "Curve name {:?} is not supported",
-                curve_name
-            ))),
-        }
-    }
-
     /// Creates a CoseSign1 structure from the given payload and some unprotected data in the form
     /// of a HeaderMap. Signs the content with the given key using the recommedations from the spec
     /// and sets the protected part of the document to reflect the algorithm used.
     pub fn new(
         payload: &[u8],
         unprotected: &HeaderMap,
-        key: &PKeyRef<Private>,
+        key: &dyn SigningPrivateKey,
     ) -> Result<Self, CoseError> {
-        let ec_key = key.ec_key().map_err(|_| CoseError::UnimplementedError)?;
-
-        let curve_name = ec_key
-            .group()
-            .curve_name()
-            .ok_or(CoseError::UnimplementedError)?;
-
-        let (sig_alg, _, _) = CoseSign1::curve_to_parameters(curve_name)?;
+        let (sig_alg, _) = key.get_parameters()?;
 
         let mut protected = HeaderMap::new();
         protected.insert(1.into(), (sig_alg as i8).into());
@@ -337,16 +351,9 @@ impl CoseSign1 {
         payload: &[u8],
         protected: &HeaderMap,
         unprotected: &HeaderMap,
-        key: &PKeyRef<Private>,
+        key: &dyn SigningPrivateKey,
     ) -> Result<Self, CoseError> {
-        let key = key.ec_key().map_err(|_| CoseError::UnimplementedError)?;
-
-        let curve_name = key
-            .group()
-            .curve_name()
-            .ok_or(CoseError::UnimplementedError)?;
-
-        let (_, digest, key_length) = CoseSign1::curve_to_parameters(curve_name)?;
+        let (_, digest) = key.get_parameters()?;
 
         // Create the SigStruct to sign
         let protected_bytes =
@@ -363,37 +370,13 @@ impl CoseSign1 {
         )
         .map_err(CoseError::SignatureError)?;
 
-        // The spec defines the signature as:
-        // Signature = I2OSP(R, n) | I2OSP(S, n), where n = ceiling(key_length / 8)
-        // The Signer interface doesn't provide this, so this will use EcdsaSig interface instead
-        // and concatenate R and S.
-        // See https://tools.ietf.org/html/rfc8017#section-4.1 for details.
-        let signature =
-            EcdsaSig::sign(struct_digest.as_ref(), &key).map_err(CoseError::SignatureError)?;
-        let bytes_r = signature.r().to_vec();
-        let bytes_s = signature.s().to_vec();
-
-        // These should *never* exceed ceiling(key_length / 8)
-        assert!(bytes_r.len() <= key_length);
-        assert!(bytes_s.len() <= key_length);
-
-        let mut signature_bytes = vec![0u8; key_length * 2];
-
-        // This is big-endian encoding so padding might be added at the start if the factor is
-        // too short.
-        let offset_copy = key_length - bytes_r.len();
-        signature_bytes[offset_copy..offset_copy + bytes_r.len()].copy_from_slice(&bytes_r);
-
-        // This is big-endian encoding so padding might be added at the start if the factor is
-        // too short.
-        let offset_copy = key_length - bytes_s.len() + key_length;
-        signature_bytes[offset_copy..offset_copy + bytes_s.len()].copy_from_slice(&bytes_s);
+        let signature = key.sign(struct_digest.as_ref())?;
 
         Ok(CoseSign1 {
             protected: ByteBuf::from(protected_bytes),
             unprotected: unprotected.clone(),
             payload: ByteBuf::from(payload.to_vec()),
-            signature: ByteBuf::from(signature_bytes),
+            signature: ByteBuf::from(signature),
         })
     }
 
@@ -443,17 +426,11 @@ impl CoseSign1 {
 
     /// This checks the signature included in the structure against the given public key and
     /// returns true if the signature matches the given key.
-    pub fn verify_signature(&self, key: &PKeyRef<Public>) -> Result<bool, CoseError> {
-        let key = key.ec_key().map_err(|_| CoseError::UnimplementedError)?;
-        // Don't support anonymous curves
-        let curve_name = key.group().curve_name().ok_or_else(|| {
-            CoseError::UnsupportedError("Anonymous curves are not supported".to_string())
-        })?;
-
+    pub fn verify_signature(&self, key: &dyn SigningPublicKey) -> Result<bool, CoseError> {
         // In theory, the digest itself does not have to match the curve, however,
         // this is the recommendation and the spec does not even provide a way to specify
         // another digest type, so, signatures will fail if this is done differently
-        let (signature_alg, digest, key_length) = CoseSign1::curve_to_parameters(curve_name)?;
+        let (signature_alg, digest) = key.get_parameters()?;
 
         // The spec reads as follows:
         //    alg:  This parameter is used to indicate the algorithm used for the
@@ -503,15 +480,7 @@ impl CoseSign1 {
         )
         .map_err(CoseError::SignatureError)?;
 
-        // Recover the R and S factors from the signature contained in the object
-        let (bytes_r, bytes_s) = self.signature.split_at(key_length);
-
-        let r = BigNum::from_slice(&bytes_r).map_err(CoseError::SignatureError)?;
-        let s = BigNum::from_slice(&bytes_s).map_err(CoseError::SignatureError)?;
-
-        let sig = EcdsaSig::from_private_components(r, s).map_err(CoseError::SignatureError)?;
-        sig.verify(&struct_digest, &key)
-            .map_err(CoseError::SignatureError)
+        key.verify(struct_digest.as_ref(), &self.signature)
     }
 
     /// This gets the `payload` and `protected` data of the document.
@@ -519,7 +488,7 @@ impl CoseSign1 {
     /// otherwise returns `Err(CoseError::UnverifiedSignature)`.
     pub fn get_protected_and_payload(
         &self,
-        key: Option<&PKeyRef<Public>>,
+        key: Option<&dyn SigningPublicKey>,
     ) -> Result<(HeaderMap, Vec<u8>), CoseError> {
         if key.is_some() && !self.verify_signature(key.unwrap())? {
             return Err(CoseError::UnverifiedSignature);
@@ -532,8 +501,8 @@ impl CoseSign1 {
     /// This gets the `payload` of the document. If `key` is provided, it only gets the payload
     /// if the signature is correctly verified, otherwise returns
     /// `Err(CoseError::UnverifiedSignature)`.
-    pub fn get_payload(&self, key: Option<&PKeyRef<Public>>) -> Result<Vec<u8>, CoseError> {
-        if key.is_some() && !self.verify_signature(&key.unwrap())? {
+    pub fn get_payload(&self, key: Option<&dyn SigningPublicKey>) -> Result<Vec<u8>, CoseError> {
+        if key.is_some() && !self.verify_signature(key.unwrap())? {
             return Err(CoseError::UnverifiedSignature);
         }
         Ok(self.payload.to_vec())
@@ -547,617 +516,632 @@ impl CoseSign1 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use openssl::pkey::PKey;
-
     // Public domain work: Pride and Prejudice by Jane Austen, taken from https://www.gutenberg.org/files/1342/1342.txt
     const TEXT: &[u8] = b"It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.";
 
-    #[test]
-    fn map_serialization() {
-        // Empty map
-        let map: HeaderMap = HeaderMap::new();
-        assert_eq!(map_to_empty_or_serialized(&map).unwrap(), []);
+    mod generic {
+        use crate::sign::*;
 
-        // Checks that the body_protected field will be serialized correctly
-        let map: HeaderMap = SignatureAlgorithm::ES256.into();
-        assert_eq!(
-            map_to_empty_or_serialized(&map).unwrap(),
-            [0xa1, 0x01, 0x26]
-        );
+        use super::TEXT;
 
-        let map: HeaderMap = SignatureAlgorithm::ES384.into();
-        assert_eq!(
-            map_to_empty_or_serialized(&map).unwrap(),
-            [0xa1, 0x01, 0x38, 0x22]
-        );
+        #[test]
+        fn map_serialization() {
+            // Empty map
+            let map: HeaderMap = HeaderMap::new();
+            assert_eq!(map_to_empty_or_serialized(&map).unwrap(), []);
 
-        let map: HeaderMap = SignatureAlgorithm::ES512.into();
-        assert_eq!(
-            map_to_empty_or_serialized(&map).unwrap(),
-            [0xa1, 0x01, 0x38, 0x23]
-        );
-    }
+            // Checks that the body_protected field will be serialized correctly
+            let map: HeaderMap = SignatureAlgorithm::ES256.into();
+            assert_eq!(
+                map_to_empty_or_serialized(&map).unwrap(),
+                [0xa1, 0x01, 0x26]
+            );
 
-    #[test]
-    fn map_with_duplicates() {
-        // Check that HeaderMaps with duplicate entries emit error
-        // {1: 42, 2: 42}
-        let test = [0xa2, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A];
-        let map: HeaderMap = serde_cbor::from_slice(&test).unwrap();
-        assert_eq!(
-            map.get(&CborValue::Integer(1)),
-            Some(&CborValue::Integer(42))
-        );
-        assert_eq!(
-            map.get(&CborValue::Integer(2)),
-            Some(&CborValue::Integer(42))
-        );
+            let map: HeaderMap = SignatureAlgorithm::ES384.into();
+            assert_eq!(
+                map_to_empty_or_serialized(&map).unwrap(),
+                [0xa1, 0x01, 0x38, 0x22]
+            );
 
-        // {1: 42, 2: 42, 1: 43}
-        let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x01, 0x18, 0x2B];
-        let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
-        assert!(map.is_err());
+            let map: HeaderMap = SignatureAlgorithm::ES512.into();
+            assert_eq!(
+                map_to_empty_or_serialized(&map).unwrap(),
+                [0xa1, 0x01, 0x38, 0x23]
+            );
+        }
 
-        // {1: 42, 2: 42, 2: 42}
-        let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x02, 0x18, 0x2A];
-        let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
-        assert!(map.is_err());
-    }
+        #[test]
+        fn map_with_duplicates() {
+            // Check that HeaderMaps with duplicate entries emit error
+            // {1: 42, 2: 42}
+            let test = [0xa2, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A];
+            let map: HeaderMap = serde_cbor::from_slice(&test).unwrap();
+            assert_eq!(
+                map.get(&CborValue::Integer(1)),
+                Some(&CborValue::Integer(42))
+            );
+            assert_eq!(
+                map.get(&CborValue::Integer(2)),
+                Some(&CborValue::Integer(42))
+            );
 
-    #[test]
-    fn sig_structure_text() {
-        let map = HeaderMap::new();
+            // {1: 42, 2: 42, 1: 43}
+            let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x01, 0x18, 0x2B];
+            let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
+            assert!(map.is_err());
 
-        let map_serialized = map_to_empty_or_serialized(&map).unwrap();
-        let sig_structure = SigStructure::new_sign1(&map_serialized, TEXT).unwrap();
+            // {1: 42, 2: 42, 2: 42}
+            let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x02, 0x18, 0x2A];
+            let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
+            assert!(map.is_err());
+        }
 
-        assert_eq!(
-            vec![
-                0x84, /* "Signature1" */
-                0x6A, 0x53, 0x69, 0x67, 0x6E, 0x61, 0x74, 0x75, 0x72, 0x65, 0x31,
-                /* protected: */
-                0x40, /* unprotected: */
-                0x40, /* payload: */
-                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E,
-            ],
-            sig_structure.as_bytes().unwrap()
-        );
+        #[test]
+        fn sig_structure_text() {
+            let map = HeaderMap::new();
 
-        let map: HeaderMap = SignatureAlgorithm::ES256.into();
-        let map_serialized = map_to_empty_or_serialized(&map).unwrap();
-        let sig_structure = SigStructure::new_sign1(&map_serialized, TEXT).unwrap();
-        assert_eq!(
-            vec![
-                0x84, /* "Signature1" */
-                0x6A, 0x53, 0x69, 0x67, 0x6E, 0x61, 0x74, 0x75, 0x72, 0x65, 0x31,
-                /* protected: */
-                0x43, 0xA1, 0x01, 0x26, /* unprotected: */
-                0x40, /* payload: */
-                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E,
-            ],
-            sig_structure.as_bytes().unwrap()
-        );
-    }
+            let map_serialized = map_to_empty_or_serialized(&map).unwrap();
+            let sig_structure = SigStructure::new_sign1(&map_serialized, TEXT).unwrap();
 
-    /// Static PRIME256V1/P-256 key to be used when cross-validating the implementation
-    fn get_ec256_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg =
-            openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1).unwrap();
-        let x = openssl::bn::BigNum::from_hex_str(
-            "9ff7423a1aace5f3e33dfaeda2c7744e3d15c2a4f6382386c93fa60c1bdb260c",
-        )
-        .unwrap();
-        let y = openssl::bn::BigNum::from_hex_str(
-            "3489e6b132f36e5ece948e73bd44231a1c3d0dacf566712a44fe8a9835d5b6fe",
-        )
-        .unwrap();
-        let d = openssl::bn::BigNum::from_hex_str(
-            "8e21d79fb6955dbe7bb592d92de4690f8bf75dc1495b2433ba78d5828e1f933f",
-        )
-        .unwrap();
+            assert_eq!(
+                vec![
+                    0x84, /* "Signature1" */
+                    0x6A, 0x53, 0x69, 0x67, 0x6E, 0x61, 0x74, 0x75, 0x72, 0x65, 0x31,
+                    /* protected: */
+                    0x40, /* unprotected: */
+                    0x40, /* payload: */
+                    0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75,
+                    0x74, 0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C,
+                    0x79, 0x20, 0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65,
+                    0x64, 0x2C, 0x20, 0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E,
+                    0x67, 0x6C, 0x65, 0x20, 0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F,
+                    0x73, 0x73, 0x65, 0x73, 0x73, 0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61,
+                    0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20, 0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65,
+                    0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20, 0x62, 0x65, 0x20, 0x69, 0x6E, 0x20,
+                    0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x77, 0x69, 0x66,
+                    0x65, 0x2E,
+                ],
+                sig_structure.as_bytes().unwrap()
+            );
 
-        let ec_public =
-            openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
-        let ec_private =
-            openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    /// Static SECP384R1/P-384 key to be used when cross-validating the implementation
-    fn get_ec384_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1).unwrap();
-        let x = openssl::bn::BigNum::from_hex_str(
-            "5a829f62f2f4f095c0e922719285b4b981c677912870a413137a5d7319916fa8\
-             584a6036951d06ffeae99ca73ab1a2dc",
-        )
-        .unwrap();
-        let y = openssl::bn::BigNum::from_hex_str(
-            "e1b76e08cb20d6afcea7423f8b49ec841dde6f210a6174750bf8136a31549422\
-             4df153184557a6c29a1d7994804f604c",
-        )
-        .unwrap();
-        let d = openssl::bn::BigNum::from_hex_str(
-            "55c6aa815a31741bc37f0ffddea73af2397bad640816ef22bfb689efc1b6cc68\
-             2a73f7e5a657248e3abad500e46d5afc",
-        )
-        .unwrap();
-        let ec_public =
-            openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
-        let ec_private =
-            openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    /// Static SECP521R1/P-512 key to be used when cross-validating the implementation
-    fn get_ec512_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP521R1).unwrap();
-        let x = openssl::bn::BigNum::from_hex_str(
-            "004365ee31a93b6e69b2c895890aaae14194cd84601bbb59587ad08ab5960522\
-             7dc7b34288e6471b0f06050763b88b4fb017f279c86030b0069100401e4016a3\
-             be8a",
-        )
-        .unwrap();
-        let y = openssl::bn::BigNum::from_hex_str(
-            "00792d772bf93cd965027df2df02d3f99ea1c4ecd18c20738ebae66854fd3afc\
-             d2ea4e902bcd37a4d2a5c639caee71513acaf7d8f7ffa11042257c5d8c697409\
-             5713",
-        )
-        .unwrap();
-        let d = openssl::bn::BigNum::from_hex_str(
-            "007c6fd88271bcd6c5d6bada258691a27700abeff0ad86891a27f93a73f00947\
-             7c53b4e069db544429ad8220d18813f5f3ab90946ebdf4f41ca929999709f7c4\
-             89e8",
-        )
-        .unwrap();
-        let ec_public =
-            openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
-        let ec_private =
-            openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    /// Randomly generate PRIME256V1/P-256 key to use for validating signining internally
-    fn generate_ec256_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg =
-            openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1).unwrap();
-        let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
-        let ec_public = openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    /// Randomly generate SECP384R1/P-384 key to use for validating signining internally
-    fn generate_ec384_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1).unwrap();
-        let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
-        let ec_public = openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    /// Randomly generate SECP521R1/P-512 key to use for validating signing internally
-    fn generate_ec512_test_key() -> (PKey<Private>, PKey<Public>) {
-        let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP521R1).unwrap();
-        let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
-        let ec_public = openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
-        (
-            PKey::from_ec_key(ec_private).unwrap(),
-            PKey::from_ec_key(ec_public).unwrap(),
-        )
-    }
-
-    #[test]
-    fn cose_sign1_ec256_validate() {
-        let (_, ec_public) = get_ec256_test_key();
-
-        // This output was validated against COSE-C implementation
-        let cose_doc = CoseSign1::from_bytes(&[
-            0xd9, 0x00, 0x12, /* tag 18 */
-            0x84, /* Protected: {1: -7} */
-            0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
-            0x58, 0x40, /* R: */
-            0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
-            0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
-            0xCE, 0x31, 0xE2, 0xD1, /* S: */
-            0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
-            0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
-            0x0F, 0xAB, 0x3C, 0xDD,
-        ])
-        .unwrap();
-
-        assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
-    }
-
-    #[test]
-    fn cose_sign1_ec384_validate() {
-        let (_, ec_public) = get_ec384_test_key();
-
-        // This output was validated against COSE-C implementation
-        let cose_doc = CoseSign1::from_bytes(&[
-            0x84, /* Protected: {1: -35} */
-            0x44, 0xA1, 0x01, 0x38, 0x22, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* signature - length 48 x 2 */
-            0x58, 0x60, /* R: */
-            0xCD, 0x42, 0xD2, 0x76, 0x32, 0xD5, 0x41, 0x4E, 0x4B, 0x54, 0x5C, 0x95, 0xFD, 0xE6,
-            0xE3, 0x50, 0x5B, 0x93, 0x58, 0x0F, 0x4B, 0x77, 0x31, 0xD1, 0x4A, 0x86, 0x52, 0x31,
-            0x75, 0x26, 0x6C, 0xDE, 0xB2, 0x4A, 0xFF, 0x2D, 0xE3, 0x36, 0x4E, 0x9C, 0xEE, 0xE9,
-            0xF9, 0xF7, 0x95, 0xA0, 0x15, 0x15, /* S: */
-            0x5B, 0xC7, 0x12, 0xAA, 0x28, 0x63, 0xE2, 0xAA, 0xF6, 0x07, 0x8A, 0x81, 0x90, 0x93,
-            0xFD, 0xFC, 0x70, 0x59, 0xA3, 0xF1, 0x46, 0x7F, 0x64, 0xEC, 0x7E, 0x22, 0x1F, 0xD1,
-            0x63, 0xD8, 0x0B, 0x3B, 0x55, 0x26, 0x25, 0xCF, 0x37, 0x9D, 0x1C, 0xBB, 0x9E, 0x51,
-            0x38, 0xCC, 0xD0, 0x7A, 0x19, 0x31,
-        ])
-        .unwrap();
-
-        assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
-    }
-
-    #[test]
-    fn cose_sign1_ec512_validate() {
-        let (_, ec_public) = get_ec512_test_key();
-
-        // This output was validated against COSE-C implementation
-        let cose_doc = CoseSign1::from_bytes(&[
-            0x84, /* Protected: {1: -36} */
-            0x44, 0xA1, 0x01, 0x38, 0x23, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* signature - length 66 x 2 */
-            0x58, 0x84, /* R: */
-            0x01, 0xE5, 0xAE, 0x6A, 0xE6, 0xE2, 0xE3, 0xC0, 0xB5, 0x1D, 0xD1, 0x62, 0x74, 0x1C,
-            0xF9, 0x9D, 0xA6, 0x88, 0x19, 0x5C, 0xD9, 0x0E, 0x65, 0xFB, 0xBE, 0xE2, 0x38, 0x83,
-            0x81, 0x32, 0x3C, 0xAE, 0xC9, 0x1B, 0x3D, 0x0E, 0x3A, 0xC1, 0x4D, 0x0B, 0x8B, 0x29,
-            0xA8, 0x56, 0x2E, 0xB2, 0x17, 0x65, 0x9F, 0x27, 0xBE, 0xB4, 0x30, 0xA1, 0xD7, 0x4F,
-            0x42, 0x35, 0x3A, 0x2C, 0x0A, 0xC5, 0x1F, 0xC2, 0x36, 0x48, /* S: */
-            0x00, 0x00, 0x89, 0xEA, 0xF7, 0x09, 0x50, 0xF8, 0x45, 0x83, 0xA7, 0xC4, 0x79, 0x2F,
-            0xAD, 0xC6, 0x96, 0xC3, 0x03, 0x33, 0xF2, 0xDF, 0x19, 0x48, 0x83, 0x93, 0xAB, 0xAE,
-            0x31, 0x6A, 0x2E, 0x17, 0x1D, 0x58, 0x87, 0x65, 0xC4, 0x36, 0xA2, 0xA2, 0x05, 0xAD,
-            0x81, 0x51, 0xF3, 0x97, 0x3E, 0xC0, 0xB4, 0xA7, 0xB8, 0x97, 0xE4, 0x90, 0x8C, 0x79,
-            0x6F, 0x85, 0x24, 0x84, 0xAE, 0x39, 0x26, 0xB3, 0xB8, 0x1B,
-        ])
-        .unwrap();
-
-        assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
-    }
-
-    #[test]
-    fn cose_sign1_ec256_text() {
-        let (ec_private, ec_public) = generate_ec256_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-        let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
-
-        assert_eq!(
-            cose_doc1.get_payload(None).unwrap(),
-            cose_doc2.get_payload(Some(&ec_public)).unwrap()
-        );
-        assert!(!cose_doc2.get_unprotected().is_empty(),);
-        assert_eq!(
-            cose_doc2.get_unprotected().get(&CborValue::Integer(4)),
-            Some(&CborValue::Bytes(b"11".to_vec())),
-        );
-    }
-
-    #[test]
-    fn cose_sign1_ec256_text_tagged() {
-        let (ec_private, ec_public) = generate_ec256_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-        let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
-        // Tag 6.18 should be present
-        assert_eq!(tagged_bytes[0], 6 << 5 | 18);
-        // The value should be a sequence
-        assert_eq!(tagged_bytes[1], 4 << 5 | 4);
-        let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
-
-        assert_eq!(
-            cose_doc1.get_payload(None).unwrap(),
-            cose_doc2.get_payload(Some(&ec_public)).unwrap()
-        );
-    }
-
-    #[test]
-    fn cose_sign1_ec256_text_tagged_serde() {
-        let (ec_private, ec_public) = generate_ec256_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-        let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
-        // Tag 6.18 should be present
-        assert_eq!(tagged_bytes[0], 6 << 5 | 18);
-        let cose_doc2: CoseSign1 = serde_cbor::from_slice(&tagged_bytes).unwrap();
-
-        assert_eq!(
-            cose_doc1.get_payload(None).unwrap(),
-            cose_doc2.get_payload(Some(&ec_public)).unwrap()
-        );
-    }
-
-    #[test]
-    fn cose_sign1_ec256_text_with_extra_protected() {
-        let (ec_private, ec_public) = generate_ec256_test_key();
-
-        let mut protected = HeaderMap::new();
-        protected.insert(
-            CborValue::Integer(1),
-            (SignatureAlgorithm::ES256 as i8).into(),
-        );
-        protected.insert(CborValue::Integer(15), CborValue::Bytes(b"12".to_vec()));
-
-        let mut unprotected = HeaderMap::new();
-        unprotected.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 =
-            CoseSign1::new_with_protected(TEXT, &protected, &unprotected, &ec_private).unwrap();
-        let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
-
-        let (protected, payload) = cose_doc2
-            .get_protected_and_payload(Some(&ec_public))
-            .unwrap();
-
-        assert_eq!(
-            protected.get(&CborValue::Integer(1)),
-            Some(&CborValue::Integer(-7)),
-        );
-        assert_eq!(
-            protected.get(&CborValue::Integer(15)),
-            Some(&CborValue::Bytes(b"12".to_vec())),
-        );
-        assert_eq!(payload, TEXT,);
-    }
-
-    #[test]
-    fn cose_sign1_ec384_text() {
-        let (ec_private, ec_public) = generate_ec384_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-        let cose_doc1_bytes = cose_doc1.as_bytes(false).unwrap();
-        // The value should be a sequence
-        assert_eq!(cose_doc1_bytes[0], 4 << 5 | 4);
-        let cose_doc2 = CoseSign1::from_bytes(&cose_doc1_bytes).unwrap();
-
-        assert_eq!(
-            cose_doc1.get_payload(None).unwrap(),
-            cose_doc2.get_payload(Some(&ec_public)).unwrap()
-        );
-    }
-
-    #[test]
-    fn cose_sign1_ec512_text() {
-        let (ec_private, ec_public) = generate_ec512_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-        let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
-
-        assert_eq!(
-            cose_doc1.get_payload(Some(&ec_public)).unwrap(),
-            TEXT.to_vec()
-        );
-        assert_eq!(
-            cose_doc1.get_payload(None).unwrap(),
-            cose_doc2.get_payload(Some(&ec_public)).unwrap()
-        );
-    }
-
-    #[test]
-    fn unknown_curve() {
-        let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP256K1).unwrap();
-        let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
-        let ec_private = PKey::from_ec_key(ec_private).unwrap();
-        let map = HeaderMap::new();
-        let result = CoseSign1::new(TEXT, &map, &ec_private);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn validate_with_wrong_key() {
-        let (ec_private, ec_public) = generate_ec512_test_key();
-        let (_, ec_public_other) = generate_ec512_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-
-        assert!(cose_doc1.verify_signature(&ec_public).unwrap());
-        assert!(!cose_doc1.verify_signature(&ec_public_other).unwrap());
-    }
-
-    #[test]
-    fn validate_with_wrong_key_type() {
-        let (ec_private, ec_public) = generate_ec512_test_key();
-        let (_, ec_public_other) = generate_ec384_test_key();
-        let mut map = HeaderMap::new();
-        map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-
-        let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
-
-        assert!(cose_doc1.verify_signature(&ec_public).unwrap());
-        assert!(!cose_doc1.verify_signature(&ec_public_other).unwrap());
-    }
-
-    #[test]
-    fn cose_sign1_ec256_tampered_content() {
-        let (_, ec_public) = get_ec256_test_key();
-
-        let cose_doc = CoseSign1::from_bytes(&[
-            0x84, /* Protected: {1: -7} */
-            0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6F, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
-            0x58, 0x40, /* R: */
-            0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
-            0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
-            0xCE, 0x31, 0xE2, 0xD1, /* S: */
-            0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
-            0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
-            0x0F, 0xAB, 0x3C, 0xDD,
-        ])
-        .unwrap();
-
-        assert!(cose_doc.get_payload(Some(&ec_public)).is_err());
-    }
-
-    #[test]
-    fn cose_sign1_ec256_tampered_signature() {
-        let (_, ec_public) = get_ec256_test_key();
-
-        let cose_doc = CoseSign1::from_bytes(&[
-            0x84, /* Protected: {1: -7} */
-            0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
-            0x58, 0x40, /* R: */
-            0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
-            0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5B, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
-            0xCE, 0x31, 0xE2, 0xD1, /* S: */
-            0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
-            0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
-            0x0F, 0xAB, 0x3C, 0xDD,
-        ])
-        .unwrap();
-
-        assert!(cose_doc.get_payload(Some(&ec_public)).is_err());
-    }
-
-    #[test]
-    fn cose_sign1_ec256_invalid_tag() {
-        let cose_doc = CoseSign1::from_bytes(&[
-            0xd3, /* tag 19 */
-            0x84, /* Protected: {1: -7} */
-            0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
-            0x58, 0x40, /* R: */
-            0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
-            0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
-            0xCE, 0x31, 0xE2, 0xD1, /* S: */
-            0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
-            0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
-            0x0F, 0xAB, 0x3C, 0xDD,
-        ]);
-
-        match cose_doc.unwrap_err() {
-            CoseError::TagError(Some(19)) => (),
-            _ => panic!(),
+            let map: HeaderMap = SignatureAlgorithm::ES256.into();
+            let map_serialized = map_to_empty_or_serialized(&map).unwrap();
+            let sig_structure = SigStructure::new_sign1(&map_serialized, TEXT).unwrap();
+            assert_eq!(
+                vec![
+                    0x84, /* "Signature1" */
+                    0x6A, 0x53, 0x69, 0x67, 0x6E, 0x61, 0x74, 0x75, 0x72, 0x65, 0x31,
+                    /* protected: */
+                    0x43, 0xA1, 0x01, 0x26, /* unprotected: */
+                    0x40, /* payload: */
+                    0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75,
+                    0x74, 0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C,
+                    0x79, 0x20, 0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65,
+                    0x64, 0x2C, 0x20, 0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E,
+                    0x67, 0x6C, 0x65, 0x20, 0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F,
+                    0x73, 0x73, 0x65, 0x73, 0x73, 0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61,
+                    0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20, 0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65,
+                    0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20, 0x62, 0x65, 0x20, 0x69, 0x6E, 0x20,
+                    0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x77, 0x69, 0x66,
+                    0x65, 0x2E,
+                ],
+                sig_structure.as_bytes().unwrap()
+            );
         }
     }
 
-    #[test]
-    fn cose_sign1_ec256_missing_tag() {
-        let cose_doc = CoseSign1::from_bytes_tagged(&[
-            0x84, /* Protected: {1: -7} */
-            0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
-            0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
-            0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
-            0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
-            0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
-            0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
-            0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
-            0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
-            0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
-            0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
-            0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
-            0x58, 0x40, /* R: */
-            0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
-            0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
-            0xCE, 0x31, 0xE2, 0xD1, /* S: */
-            0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
-            0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
-            0x0F, 0xAB, 0x3C, 0xDD,
-        ]);
+    #[cfg(feature = "key_openssl_pkey")]
+    mod openssl {
+        use crate::sign::*;
+        use openssl::pkey::{PKey, Private, Public};
 
-        match cose_doc.unwrap_err() {
-            CoseError::TagError(None) => (),
-            _ => panic!(),
+        use super::TEXT;
+
+        /// Static PRIME256V1/P-256 key to be used when cross-validating the implementation
+        fn get_ec256_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg =
+                openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1).unwrap();
+            let x = openssl::bn::BigNum::from_hex_str(
+                "9ff7423a1aace5f3e33dfaeda2c7744e3d15c2a4f6382386c93fa60c1bdb260c",
+            )
+            .unwrap();
+            let y = openssl::bn::BigNum::from_hex_str(
+                "3489e6b132f36e5ece948e73bd44231a1c3d0dacf566712a44fe8a9835d5b6fe",
+            )
+            .unwrap();
+            let d = openssl::bn::BigNum::from_hex_str(
+                "8e21d79fb6955dbe7bb592d92de4690f8bf75dc1495b2433ba78d5828e1f933f",
+            )
+            .unwrap();
+
+            let ec_public =
+                openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
+            let ec_private =
+                openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key())
+                    .unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        /// Static SECP384R1/P-384 key to be used when cross-validating the implementation
+        fn get_ec384_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1).unwrap();
+            let x = openssl::bn::BigNum::from_hex_str(
+                "5a829f62f2f4f095c0e922719285b4b981c677912870a413137a5d7319916fa8\
+            584a6036951d06ffeae99ca73ab1a2dc",
+            )
+            .unwrap();
+            let y = openssl::bn::BigNum::from_hex_str(
+                "e1b76e08cb20d6afcea7423f8b49ec841dde6f210a6174750bf8136a31549422\
+            4df153184557a6c29a1d7994804f604c",
+            )
+            .unwrap();
+            let d = openssl::bn::BigNum::from_hex_str(
+                "55c6aa815a31741bc37f0ffddea73af2397bad640816ef22bfb689efc1b6cc68\
+            2a73f7e5a657248e3abad500e46d5afc",
+            )
+            .unwrap();
+            let ec_public =
+                openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
+            let ec_private =
+                openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key())
+                    .unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        /// Static SECP521R1/P-512 key to be used when cross-validating the implementation
+        fn get_ec512_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP521R1).unwrap();
+            let x = openssl::bn::BigNum::from_hex_str(
+                "004365ee31a93b6e69b2c895890aaae14194cd84601bbb59587ad08ab5960522\
+            7dc7b34288e6471b0f06050763b88b4fb017f279c86030b0069100401e4016a3\
+            be8a",
+            )
+            .unwrap();
+            let y = openssl::bn::BigNum::from_hex_str(
+                "00792d772bf93cd965027df2df02d3f99ea1c4ecd18c20738ebae66854fd3afc\
+            d2ea4e902bcd37a4d2a5c639caee71513acaf7d8f7ffa11042257c5d8c697409\
+            5713",
+            )
+            .unwrap();
+            let d = openssl::bn::BigNum::from_hex_str(
+                "007c6fd88271bcd6c5d6bada258691a27700abeff0ad86891a27f93a73f00947\
+            7c53b4e069db544429ad8220d18813f5f3ab90946ebdf4f41ca929999709f7c4\
+            89e8",
+            )
+            .unwrap();
+            let ec_public =
+                openssl::ec::EcKey::from_public_key_affine_coordinates(&alg, &x, &y).unwrap();
+            let ec_private =
+                openssl::ec::EcKey::from_private_components(&alg, &d, &ec_public.public_key())
+                    .unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        /// Randomly generate PRIME256V1/P-256 key to use for validating signining internally
+        fn generate_ec256_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg =
+                openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1).unwrap();
+            let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
+            let ec_public =
+                openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        /// Randomly generate SECP384R1/P-384 key to use for validating signining internally
+        fn generate_ec384_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP384R1).unwrap();
+            let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
+            let ec_public =
+                openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        /// Randomly generate SECP521R1/P-512 key to use for validating signing internally
+        fn generate_ec512_test_key() -> (PKey<Private>, PKey<Public>) {
+            let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP521R1).unwrap();
+            let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
+            let ec_public =
+                openssl::ec::EcKey::from_public_key(&alg, ec_private.public_key()).unwrap();
+            (
+                PKey::from_ec_key(ec_private).unwrap(),
+                PKey::from_ec_key(ec_public).unwrap(),
+            )
+        }
+
+        #[test]
+        fn cose_sign1_ec256_validate() {
+            let (_, ec_public) = get_ec256_test_key();
+
+            // This output was validated against COSE-C implementation
+            let cose_doc = CoseSign1::from_bytes(&[
+                0xd9, 0x00, 0x12, /* tag 18 */
+                0x84, /* Protected: {1: -7} */
+                0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
+                0x58, 0x40, /* R: */
+                0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
+                0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
+                0xCE, 0x31, 0xE2, 0xD1, /* S: */
+                0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
+                0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
+                0x0F, 0xAB, 0x3C, 0xDD,
+            ])
+            .unwrap();
+
+            assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
+        }
+
+        #[test]
+        fn cose_sign1_ec384_validate() {
+            let (_, ec_public) = get_ec384_test_key();
+
+            // This output was validated against COSE-C implementation
+            let cose_doc = CoseSign1::from_bytes(&[
+                0x84, /* Protected: {1: -35} */
+                0x44, 0xA1, 0x01, 0x38, 0x22, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* signature - length 48 x 2 */
+                0x58, 0x60, /* R: */
+                0xCD, 0x42, 0xD2, 0x76, 0x32, 0xD5, 0x41, 0x4E, 0x4B, 0x54, 0x5C, 0x95, 0xFD, 0xE6,
+                0xE3, 0x50, 0x5B, 0x93, 0x58, 0x0F, 0x4B, 0x77, 0x31, 0xD1, 0x4A, 0x86, 0x52, 0x31,
+                0x75, 0x26, 0x6C, 0xDE, 0xB2, 0x4A, 0xFF, 0x2D, 0xE3, 0x36, 0x4E, 0x9C, 0xEE, 0xE9,
+                0xF9, 0xF7, 0x95, 0xA0, 0x15, 0x15, /* S: */
+                0x5B, 0xC7, 0x12, 0xAA, 0x28, 0x63, 0xE2, 0xAA, 0xF6, 0x07, 0x8A, 0x81, 0x90, 0x93,
+                0xFD, 0xFC, 0x70, 0x59, 0xA3, 0xF1, 0x46, 0x7F, 0x64, 0xEC, 0x7E, 0x22, 0x1F, 0xD1,
+                0x63, 0xD8, 0x0B, 0x3B, 0x55, 0x26, 0x25, 0xCF, 0x37, 0x9D, 0x1C, 0xBB, 0x9E, 0x51,
+                0x38, 0xCC, 0xD0, 0x7A, 0x19, 0x31,
+            ])
+            .unwrap();
+
+            assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
+        }
+
+        #[test]
+        fn cose_sign1_ec512_validate() {
+            let (_, ec_public) = get_ec512_test_key();
+
+            // This output was validated against COSE-C implementation
+            let cose_doc = CoseSign1::from_bytes(&[
+                0x84, /* Protected: {1: -36} */
+                0x44, 0xA1, 0x01, 0x38, 0x23, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* signature - length 66 x 2 */
+                0x58, 0x84, /* R: */
+                0x01, 0xE5, 0xAE, 0x6A, 0xE6, 0xE2, 0xE3, 0xC0, 0xB5, 0x1D, 0xD1, 0x62, 0x74, 0x1C,
+                0xF9, 0x9D, 0xA6, 0x88, 0x19, 0x5C, 0xD9, 0x0E, 0x65, 0xFB, 0xBE, 0xE2, 0x38, 0x83,
+                0x81, 0x32, 0x3C, 0xAE, 0xC9, 0x1B, 0x3D, 0x0E, 0x3A, 0xC1, 0x4D, 0x0B, 0x8B, 0x29,
+                0xA8, 0x56, 0x2E, 0xB2, 0x17, 0x65, 0x9F, 0x27, 0xBE, 0xB4, 0x30, 0xA1, 0xD7, 0x4F,
+                0x42, 0x35, 0x3A, 0x2C, 0x0A, 0xC5, 0x1F, 0xC2, 0x36, 0x48, /* S: */
+                0x00, 0x00, 0x89, 0xEA, 0xF7, 0x09, 0x50, 0xF8, 0x45, 0x83, 0xA7, 0xC4, 0x79, 0x2F,
+                0xAD, 0xC6, 0x96, 0xC3, 0x03, 0x33, 0xF2, 0xDF, 0x19, 0x48, 0x83, 0x93, 0xAB, 0xAE,
+                0x31, 0x6A, 0x2E, 0x17, 0x1D, 0x58, 0x87, 0x65, 0xC4, 0x36, 0xA2, 0xA2, 0x05, 0xAD,
+                0x81, 0x51, 0xF3, 0x97, 0x3E, 0xC0, 0xB4, 0xA7, 0xB8, 0x97, 0xE4, 0x90, 0x8C, 0x79,
+                0x6F, 0x85, 0x24, 0x84, 0xAE, 0x39, 0x26, 0xB3, 0xB8, 0x1B,
+            ])
+            .unwrap();
+
+            assert_eq!(cose_doc.get_payload(Some(&ec_public)).unwrap(), TEXT);
+        }
+        #[test]
+        fn cose_sign1_ec256_text() {
+            let (ec_private, ec_public) = generate_ec256_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+            let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
+
+            assert_eq!(
+                cose_doc1.get_payload(None).unwrap(),
+                cose_doc2.get_payload(Some(&ec_public)).unwrap()
+            );
+            assert!(!cose_doc2.get_unprotected().is_empty(),);
+            assert_eq!(
+                cose_doc2.get_unprotected().get(&CborValue::Integer(4)),
+                Some(&CborValue::Bytes(b"11".to_vec())),
+            );
+        }
+
+        #[test]
+        fn cose_sign1_ec256_text_tagged() {
+            let (ec_private, ec_public) = generate_ec256_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+            let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
+            // Tag 6.18 should be present
+            assert_eq!(tagged_bytes[0], 6 << 5 | 18);
+            // The value should be a sequence
+            assert_eq!(tagged_bytes[1], 4 << 5 | 4);
+            let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
+
+            assert_eq!(
+                cose_doc1.get_payload(None).unwrap(),
+                cose_doc2.get_payload(Some(&ec_public)).unwrap()
+            );
+        }
+
+        #[test]
+        fn cose_sign1_ec256_text_tagged_serde() {
+            let (ec_private, ec_public) = generate_ec256_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+            let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
+            // Tag 6.18 should be present
+            assert_eq!(tagged_bytes[0], 6 << 5 | 18);
+            let cose_doc2: CoseSign1 = serde_cbor::from_slice(&tagged_bytes).unwrap();
+
+            assert_eq!(
+                cose_doc1.get_payload(None).unwrap(),
+                cose_doc2.get_payload(Some(&ec_public)).unwrap()
+            );
+        }
+
+        #[test]
+        fn cose_sign1_ec256_text_with_extra_protected() {
+            let (ec_private, ec_public) = generate_ec256_test_key();
+
+            let mut protected = HeaderMap::new();
+            protected.insert(
+                CborValue::Integer(1),
+                (SignatureAlgorithm::ES256 as i8).into(),
+            );
+            protected.insert(CborValue::Integer(15), CborValue::Bytes(b"12".to_vec()));
+
+            let mut unprotected = HeaderMap::new();
+            unprotected.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 =
+                CoseSign1::new_with_protected(TEXT, &protected, &unprotected, &ec_private).unwrap();
+            let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
+
+            let (protected, payload) = cose_doc2
+                .get_protected_and_payload(Some(&ec_public))
+                .unwrap();
+
+            assert_eq!(
+                protected.get(&CborValue::Integer(1)),
+                Some(&CborValue::Integer(-7)),
+            );
+            assert_eq!(
+                protected.get(&CborValue::Integer(15)),
+                Some(&CborValue::Bytes(b"12".to_vec())),
+            );
+            assert_eq!(payload, TEXT,);
+        }
+
+        #[test]
+        fn cose_sign1_ec384_text() {
+            let (ec_private, ec_public) = generate_ec384_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+            let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
+
+            assert_eq!(
+                cose_doc1.get_payload(None).unwrap(),
+                cose_doc2.get_payload(Some(&ec_public)).unwrap()
+            );
+        }
+
+        #[test]
+        fn cose_sign1_ec512_text() {
+            let (ec_private, ec_public) = generate_ec512_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+            let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
+
+            assert_eq!(
+                cose_doc1.get_payload(Some(&ec_public)).unwrap(),
+                TEXT.to_vec()
+            );
+            assert_eq!(
+                cose_doc1.get_payload(None).unwrap(),
+                cose_doc2.get_payload(Some(&ec_public)).unwrap()
+            );
+        }
+
+        #[test]
+        fn unknown_curve() {
+            let alg = openssl::ec::EcGroup::from_curve_name(openssl::nid::Nid::SECP256K1).unwrap();
+            let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
+            let ec_private = PKey::from_ec_key(ec_private).unwrap();
+            let map = HeaderMap::new();
+            let result = CoseSign1::new(TEXT, &map, &ec_private);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn validate_with_wrong_key() {
+            let (ec_private, ec_public) = generate_ec512_test_key();
+            let (_, ec_public_other) = generate_ec512_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+
+            assert!(cose_doc1.verify_signature(&ec_public).unwrap());
+            assert!(!cose_doc1.verify_signature(&ec_public_other).unwrap());
+        }
+
+        #[test]
+        fn validate_with_wrong_key_type() {
+            let (ec_private, ec_public) = generate_ec512_test_key();
+            let (_, ec_public_other) = generate_ec384_test_key();
+            let mut map = HeaderMap::new();
+            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+
+            let cose_doc1 = CoseSign1::new(TEXT, &map, &ec_private).unwrap();
+
+            assert!(cose_doc1.verify_signature(&ec_public).unwrap());
+            assert!(!cose_doc1.verify_signature(&ec_public_other).unwrap());
+        }
+
+        #[test]
+        fn cose_sign1_ec256_tampered_content() {
+            let (_, ec_public) = get_ec256_test_key();
+
+            let cose_doc = CoseSign1::from_bytes(&[
+                0x84, /* Protected: {1: -7} */
+                0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6F, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
+                0x58, 0x40, /* R: */
+                0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
+                0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
+                0xCE, 0x31, 0xE2, 0xD1, /* S: */
+                0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
+                0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
+                0x0F, 0xAB, 0x3C, 0xDD,
+            ])
+            .unwrap();
+
+            assert!(cose_doc.get_payload(Some(&ec_public)).is_err());
+        }
+
+        #[test]
+        fn cose_sign1_ec256_tampered_signature() {
+            let (_, ec_public) = get_ec256_test_key();
+
+            let cose_doc = CoseSign1::from_bytes(&[
+                0x84, /* Protected: {1: -7} */
+                0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
+                0x58, 0x40, /* R: */
+                0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
+                0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5B, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
+                0xCE, 0x31, 0xE2, 0xD1, /* S: */
+                0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
+                0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
+                0x0F, 0xAB, 0x3C, 0xDD,
+            ])
+            .unwrap();
+
+            assert!(cose_doc.get_payload(Some(&ec_public)).is_err());
+        }
+
+        #[test]
+        fn cose_sign1_ec256_invalid_tag() {
+            let cose_doc = CoseSign1::from_bytes(&[
+                0xd3, /* tag 19 */
+                0x84, /* Protected: {1: -7} */
+                0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
+                0x58, 0x40, /* R: */
+                0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
+                0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
+                0xCE, 0x31, 0xE2, 0xD1, /* S: */
+                0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
+                0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
+                0x0F, 0xAB, 0x3C, 0xDD,
+            ]);
+
+            match cose_doc.unwrap_err() {
+                CoseError::TagError(Some(19)) => (),
+                _ => panic!(),
+            }
+        }
+
+        #[test]
+        fn cose_sign1_ec256_missing_tag() {
+            let cose_doc = CoseSign1::from_bytes_tagged(&[
+                0x84, /* Protected: {1: -7} */
+                0x43, 0xA1, 0x01, 0x26, /* Unprotected: {4: '11'} */
+                0xA1, 0x04, 0x42, 0x31, 0x31, /* payload: */
+                0x58, 0x75, 0x49, 0x74, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x74, 0x72, 0x75, 0x74,
+                0x68, 0x20, 0x75, 0x6E, 0x69, 0x76, 0x65, 0x72, 0x73, 0x61, 0x6C, 0x6C, 0x79, 0x20,
+                0x61, 0x63, 0x6B, 0x6E, 0x6F, 0x77, 0x6C, 0x65, 0x64, 0x67, 0x65, 0x64, 0x2C, 0x20,
+                0x74, 0x68, 0x61, 0x74, 0x20, 0x61, 0x20, 0x73, 0x69, 0x6E, 0x67, 0x6C, 0x65, 0x20,
+                0x6D, 0x61, 0x6E, 0x20, 0x69, 0x6E, 0x20, 0x70, 0x6F, 0x73, 0x73, 0x65, 0x73, 0x73,
+                0x69, 0x6F, 0x6E, 0x20, 0x6F, 0x66, 0x20, 0x61, 0x20, 0x67, 0x6F, 0x6F, 0x64, 0x20,
+                0x66, 0x6F, 0x72, 0x74, 0x75, 0x6E, 0x65, 0x2C, 0x20, 0x6D, 0x75, 0x73, 0x74, 0x20,
+                0x62, 0x65, 0x20, 0x69, 0x6E, 0x20, 0x77, 0x61, 0x6E, 0x74, 0x20, 0x6F, 0x66, 0x20,
+                0x61, 0x20, 0x77, 0x69, 0x66, 0x65, 0x2E, /* Signature - length 32 x 2 */
+                0x58, 0x40, /* R: */
+                0x6E, 0x6D, 0xF6, 0x54, 0x89, 0xEA, 0x3B, 0x01, 0x88, 0x33, 0xF5, 0xFC, 0x4F, 0x84,
+                0xF8, 0x1B, 0x4D, 0x5E, 0xFD, 0x5A, 0x09, 0xD5, 0xC6, 0x2F, 0x2E, 0x92, 0x38, 0x5D,
+                0xCE, 0x31, 0xE2, 0xD1, /* S: */
+                0x5A, 0x53, 0xA9, 0xF0, 0x75, 0xE8, 0xFB, 0x39, 0x66, 0x9F, 0xCD, 0x4E, 0xB5, 0x22,
+                0xC8, 0x5C, 0x92, 0x77, 0x45, 0x2F, 0xA8, 0x57, 0xF5, 0xFE, 0x37, 0x9E, 0xDD, 0xEF,
+                0x0F, 0xAB, 0x3C, 0xDD,
+            ]);
+
+            match cose_doc.unwrap_err() {
+                CoseError::TagError(None) => (),
+                _ => panic!(),
+            }
         }
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -357,7 +357,7 @@ impl CoseSign1 {
 
         // Create the SigStruct to sign
         let protected_bytes =
-            map_to_empty_or_serialized(&protected).map_err(CoseError::SerializationError)?;
+            map_to_empty_or_serialized(protected).map_err(CoseError::SerializationError)?;
 
         let sig_structure = SigStructure::new_sign1(&protected_bytes, payload)
             .map_err(CoseError::SerializationError)?;


### PR DESCRIPTION
This abstracts the cryptographic implementations of symmetric crypto and
computing message digests.
This makes it possible to fully swap out openssl with something else if
that were to get implemented.
    
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Apache License Version 2.0, as specified in the LICENSE file of this repository.