### PR TITLE
Add test with test vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ tss-esapi = { version = "6.1", optional = true }
 version = "1.0"
 features = ["derive"]
 
+[dev-dependencies]
+hex = "0.4"
+
 [features]
 default = ["key_openssl_pkey"]
 key_openssl_pkey = []


### PR DESCRIPTION
This adds the test vector from RFC8152, appendix C, section C.2.1, and
runs a signature validation test.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Apache License Version 2.0, as specified in the LICENSE file of this repository.