### PR TITLE
Crypto abstraction using dependency injection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,20 @@ env:
 
 jobs:
     test:
-        name: Test on rust ${{matrix.rust}}
+        name: Test on rust ${{matrix.rust}}  (keys ${{ matrix.key_feature_set }})
         runs-on: ubuntu-latest
         strategy:
             matrix:
                 rust: [1.46.0, stable, nightly]
+                key_feature_set:
+                  - key_openssl_pkey
+                  - key_tpm
         steps:
         - uses: actions/checkout@v2
         - uses: dtolnay/rust-toolchain@master
           with:
               toolchain: ${{matrix.rust}}
-        - run: cargo test --all
+        - run: cargo test --all --no-default-features --features ${{ matrix.key_feature_set }}
 
     test_fedora:
         name: Test on Fedora

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
                 rust: [1.46.0, stable, nightly]
                 key_feature_set:
                   - key_openssl_pkey
-                  - key_tpm
         steps:
         - uses: actions/checkout@v2
         - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,3 @@ hex = "0.4"
 default = ["key_openssl_pkey"]
 key_openssl_pkey = ["openssl"]
 key_tpm = ["tss-esapi", "openssl"]
-
-[patch.crates-io]
-serde_bytes = { git = "https://github.com/fortanix/bytes.git", branch = "raoul/no_std_compatibility" }
-serde = { git = "https://github.com/fortanix/serde.git", branch = "raoul/stdlib_1.0.136" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_cbor = { version="0.11", features = ["tags"] }
 serde_repr = "0.1"
 serde_bytes = "0.11"
 serde_with = { version = "1.5", default_features = false }
-openssl = "0.10"
+openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "6.1", optional = true }
 
 [dependencies.serde]
@@ -26,5 +26,5 @@ hex = "0.4"
 
 [features]
 default = ["key_openssl_pkey"]
-key_openssl_pkey = []
-key_tpm = ["tss-esapi"]
+key_openssl_pkey = ["openssl"]
+key_tpm = ["tss-esapi", "openssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.5.0"
+version = "0.4.0"
 authors = ["Petre Eftime <epetre@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ description = "This library aims to provide a safe Rust implementation of COSE, 
 [dependencies]
 serde_cbor = { version="0.11", features = ["tags"] }
 serde_repr = "0.1"
-serde_bytes = "0.11"
+serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "1.5", default_features = false }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "6.1", optional = true }
@@ -28,3 +28,7 @@ hex = "0.4"
 default = ["key_openssl_pkey"]
 key_openssl_pkey = ["openssl"]
 key_tpm = ["tss-esapi", "openssl"]
+
+[patch.crates-io]
+serde_bytes = { git = "https://github.com/fortanix/bytes.git", branch = "raoul/no_std_compatibility" }
+serde = { git = "https://github.com/fortanix/serde.git", branch = "raoul/stdlib_1.0.136" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Petre Eftime <epetre@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -90,6 +90,7 @@ pub trait Decryption {
 }
 
 /// Cryptographic hash algorithms that can be used with the `Hash` trait
+#[derive(Debug, Copy, Clone)]
 pub enum MessageDigest {
     /// 256-bit Secure Hash Algorithm
     Sha256,

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,6 +1,6 @@
 //! (Signing) cryptography abstraction
 
-use crate::encrypt::COSEAlgorithm;
+use crate::encrypt::CoseAlgorithm;
 use crate::error::CoseError;
 use crate::header_map::HeaderMap;
 #[cfg(feature = "openssl")]
@@ -12,18 +12,21 @@ use std::str::FromStr;
 mod openssl;
 
 #[cfg(feature = "openssl")]
-pub use self::openssl::OpenSSL;
+pub use self::openssl::Openssl;
 
 #[cfg(feature = "key_openssl_pkey")]
 mod openssl_pkey;
 #[cfg(feature = "key_tpm")]
 pub mod tpm;
 
-/// A trait exposing various aead encryption algorithms.
-pub trait Encryption {
+/// A trait exposing a source of entropy
+pub trait Entropy {
     /// Fill the provided `buff` with cryptographic random values.
     fn rand_bytes(buff: &mut [u8]) -> Result<(), CoseError>;
+}
 
+/// A trait exposing various aead encryption algorithms.
+pub trait Encryption {
     /// Encryption for AEAD ciphers such as AES GCM.
     ///
     /// Additional Authenticated Data (AEAD) can be provided in the `aad` field, and the authentication tag
@@ -52,12 +55,12 @@ pub enum EncryptionAlgorithm {
     Aes256Gcm,
 }
 
-impl From<COSEAlgorithm> for EncryptionAlgorithm {
-    fn from(algo: COSEAlgorithm) -> EncryptionAlgorithm {
+impl From<CoseAlgorithm> for EncryptionAlgorithm {
+    fn from(algo: CoseAlgorithm) -> EncryptionAlgorithm {
         match algo {
-            COSEAlgorithm::AesGcm96_128_128 => EncryptionAlgorithm::Aes128Gcm,
-            COSEAlgorithm::AesGcm96_128_192 => EncryptionAlgorithm::Aes192Gcm,
-            COSEAlgorithm::AesGcm96_128_256 => EncryptionAlgorithm::Aes256Gcm,
+            CoseAlgorithm::AesGcm96_128_128 => EncryptionAlgorithm::Aes128Gcm,
+            CoseAlgorithm::AesGcm96_128_192 => EncryptionAlgorithm::Aes192Gcm,
+            CoseAlgorithm::AesGcm96_128_256 => EncryptionAlgorithm::Aes256Gcm,
         }
     }
 }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,12 +1,9 @@
 //! (Signing) cryptography abstraction
 
-use ::openssl::hash::MessageDigest;
+use crate::encrypt::COSEAlgorithm;
+use crate::{error::CoseError, sign::SignatureAlgorithm};
 use ::openssl::nid::Nid;
 use ::openssl::symm::Cipher;
-
-use crate::encrypt::COSEAlgorithm;
-use crate::error::CoseError;
-use crate::sign::SignatureAlgorithm;
 
 mod openssl;
 pub use self::openssl::OpenSSL;
@@ -83,6 +80,32 @@ pub trait Decryption {
         data: &[u8],
         tag: &[u8],
     ) -> Result<Vec<u8>, CoseError>;
+}
+
+/// Cryptographic hash algorithms that can be used with the `Hash` trait
+pub enum MessageDigest {
+    /// 256-bit Secure Hash Algorithm
+    Sha256,
+    /// 384-bit Secure Hash Algorithm
+    Sha384,
+    /// 512-bit Secure Hash Algorithm
+    Sha512,
+}
+
+impl From<MessageDigest> for ::openssl::hash::MessageDigest {
+    fn from(digest: MessageDigest) -> Self {
+        match digest {
+            MessageDigest::Sha256 => ::openssl::hash::MessageDigest::sha256(),
+            MessageDigest::Sha384 => ::openssl::hash::MessageDigest::sha384(),
+            MessageDigest::Sha512 => ::openssl::hash::MessageDigest::sha512(),
+        }
+    }
+}
+
+/// A trait exposing various cryptographic hash algorithms
+pub trait Hash {
+    /// Computes the hash of the `data` with provided hash function
+    fn hash(digest: MessageDigest, data: &[u8]) -> Result<Vec<u8>, CoseError>;
 }
 
 /// A public key that can verify an existing signature

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -1,4 +1,4 @@
-use super::{Decryption, Encryption, EncryptionAlgorithm};
+use super::{Decryption, Encryption, EncryptionAlgorithm, Hash, MessageDigest};
 use crate::error::CoseError;
 use openssl::symm::Cipher;
 
@@ -52,5 +52,13 @@ impl Decryption for OpenSSL {
         let cipher: Cipher = algo.into();
         openssl::symm::decrypt_aead(cipher, key, iv, aad, ciphertext, tag)
             .map_err(|e| CoseError::EncryptionError(Box::new(e)))
+    }
+}
+
+impl Hash for OpenSSL {
+    fn hash(digest: MessageDigest, data: &[u8]) -> Result<Vec<u8>, CoseError> {
+        openssl::hash::hash(digest.into(), data)
+            .map_err(|e| CoseError::HashingError(Box::new(e)))
+            .map(|h| h.to_vec())
     }
 }

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -1,15 +1,17 @@
-use super::{Decryption, Encryption, EncryptionAlgorithm, Hash, MessageDigest};
+use super::{Decryption, Encryption, EncryptionAlgorithm, Entropy, Hash, MessageDigest};
 use crate::error::CoseError;
 use openssl::symm::Cipher;
 
 /// Type that implements various cryptographic traits using the OpenSSL library
-pub struct OpenSSL;
+pub struct Openssl;
 
-impl Encryption for OpenSSL {
+impl Entropy for Openssl {
     fn rand_bytes(buff: &mut [u8]) -> Result<(), CoseError> {
-        openssl::rand::rand_bytes(buff).map_err(|e| CoseError::RandomnessFailed(Box::new(e)))
+        openssl::rand::rand_bytes(buff).map_err(|e| CoseError::EntropyError(Box::new(e)))
     }
+}
 
+impl Encryption for Openssl {
     /// Like `encrypt`, but for AEAD ciphers such as AES GCM.
     ///
     /// Additional Authenticated Data can be provided in the `aad` field, and the authentication tag
@@ -36,7 +38,7 @@ impl Encryption for OpenSSL {
     }
 }
 
-impl Decryption for OpenSSL {
+impl Decryption for Openssl {
     /// Like `decrypt`, but for AEAD ciphers such as AES GCM.
     ///
     /// Additional Authenticated Data can be provided in the `aad` field, and the authentication tag
@@ -55,7 +57,7 @@ impl Decryption for OpenSSL {
     }
 }
 
-impl Hash for OpenSSL {
+impl Hash for Openssl {
     fn hash(digest: MessageDigest, data: &[u8]) -> Result<Vec<u8>, CoseError> {
         openssl::hash::hash(digest.into(), data)
             .map_err(|e| CoseError::HashingError(Box::new(e)))

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -1,0 +1,37 @@
+use super::{Encryption, EncryptionAlgorithm};
+use crate::error::CoseError;
+use openssl::symm::Cipher;
+
+/// Type that implements various cryptographic traits using the OpenSSL library
+pub struct OpenSSL;
+
+impl Encryption for OpenSSL {
+    fn rand_bytes(buff: &mut [u8]) -> Result<(), CoseError> {
+        openssl::rand::rand_bytes(buff).map_err(|e| CoseError::RandomnessFailed(Box::new(e)))
+    }
+
+    /// Like `encrypt`, but for AEAD ciphers such as AES GCM.
+    ///
+    /// Additional Authenticated Data can be provided in the `aad` field, and the authentication tag
+    /// will be copied into the `tag` field.
+    ///
+    /// The size of the `tag` buffer indicates the required size of the tag. While some ciphers support
+    /// a range of tag sizes, it is recommended to pick the maximum size. For AES GCM, this is 16 bytes,
+    /// for example.
+    fn encrypt_aead(
+        algo: EncryptionAlgorithm,
+        key: &[u8],
+        iv: Option<&[u8]>,
+        aad: &[u8],
+        data: &[u8],
+        tag: &mut [u8],
+    ) -> Result<Vec<u8>, CoseError> {
+        let cipher = match algo {
+            EncryptionAlgorithm::Aes128Gcm => Cipher::aes_128_gcm(),
+            EncryptionAlgorithm::Aes192Gcm => Cipher::aes_192_gcm(),
+            EncryptionAlgorithm::Aes256Gcm => Cipher::aes_256_gcm(),
+        };
+        openssl::symm::encrypt_aead(cipher, key, iv, aad, data, tag)
+            .map_err(|e| CoseError::EncryptionError(Box::new(e)))
+    }
+}

--- a/src/crypto/openssl_pkey.rs
+++ b/src/crypto/openssl_pkey.rs
@@ -8,9 +8,8 @@ use openssl::{
 };
 
 use crate::{
-    crypto::{MessageDigest, SigningPrivateKey, SigningPublicKey},
+    crypto::{MessageDigest, SignatureAlgorithm, SigningPrivateKey, SigningPublicKey},
     error::CoseError,
-    sign::SignatureAlgorithm,
 };
 
 /// Follows the recommandations put in place by the RFC and doesn't deal with potential

--- a/src/crypto/tpm.rs
+++ b/src/crypto/tpm.rs
@@ -2,7 +2,6 @@
 
 use std::{cell::RefCell, convert::TryInto};
 
-use openssl::hash::MessageDigest;
 use tss_esapi::{
     constants::{
         self as tpm_constants,
@@ -16,9 +15,8 @@ use tss_esapi::{
 };
 
 use crate::{
-    crypto::{SigningPrivateKey, SigningPublicKey},
+    crypto::{MessageDigest, SignatureAlgorithm, SigningPrivateKey, SigningPublicKey},
     error::CoseError,
-    sign::SignatureAlgorithm,
 };
 
 const TSS2_RC_SIGNATURE: u32 = tpm_constants::tss::TPM2_RC_SIGNATURE
@@ -74,9 +72,9 @@ impl TpmKey {
 
         let scheme = unsafe { params.scheme.details.ecdsa };
         let param_hash_alg = match scheme.hashAlg {
-            tpm_constants::tss::TPM2_ALG_SHA256 => MessageDigest::sha256(),
-            tpm_constants::tss::TPM2_ALG_SHA384 => MessageDigest::sha384(),
-            tpm_constants::tss::TPM2_ALG_SHA512 => MessageDigest::sha512(),
+            tpm_constants::tss::TPM2_ALG_SHA256 => MessageDigest::Sha256,
+            tpm_constants::tss::TPM2_ALG_SHA384 => MessageDigest::Sha384,
+            tpm_constants::tss::TPM2_ALG_SHA512 => MessageDigest::Sha512,
             hash_alg => {
                 return Err(CoseError::UnsupportedError(format!(
                     "Key hash alg {} is not supported",

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -360,7 +360,7 @@ impl CoseEncrypt0 {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "openssl"))]
 mod tests {
     use super::*;
     use crate::crypto::OpenSSL;

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ use serde_cbor::Error as CborError;
 #[derive(Debug)]
 /// Aggregation of all error types returned by this library
 pub enum CoseError {
+    /// Failed to generate random bytes
+    RandomnessFailed(Box<dyn Error>),
     /// Signature could not be performed due to OpenSSL error.
     SignatureError(openssl::error::ErrorStack),
     /// This feature is not yet fully implemented according
@@ -25,7 +27,7 @@ pub enum CoseError {
     /// Tag is missing or incorrect.
     TagError(Option<u64>),
     /// Encryption could not be performed due to OpenSSL error.
-    EncryptionError(openssl::error::ErrorStack),
+    EncryptionError(Box<dyn Error>),
     /// TPM error occured
     #[cfg(feature = "key_tpm")]
     TpmError(tss_esapi::Error),
@@ -34,6 +36,7 @@ pub enum CoseError {
 impl fmt::Display for CoseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            CoseError::RandomnessFailed(e) => write!(f, "Randomness error: {}", e),
             CoseError::SignatureError(e) => write!(f, "Signature error: {}", e),
             CoseError::UnimplementedError => write!(f, "Not implemented"),
             CoseError::UnsupportedError(e) => write!(f, "Not supported: {}", e),

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ use serde_cbor::Error as CborError;
 /// Aggregation of all error types returned by this library
 pub enum CoseError {
     /// Failed to generate random bytes
-    RandomnessFailed(Box<dyn Error>),
+    EntropyError(Box<dyn Error>),
     /// Computation of a cryptographic hash failed
     HashingError(Box<dyn Error>),
     /// Signature could not be performed due to OpenSSL error.
@@ -38,7 +38,7 @@ pub enum CoseError {
 impl fmt::Display for CoseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CoseError::RandomnessFailed(e) => write!(f, "Randomness error: {}", e),
+            CoseError::EntropyError(e) => write!(f, "Entropy error: {}", e),
             CoseError::HashingError(e) => write!(f, "Hashing failed: {}", e),
             CoseError::SignatureError(e) => write!(f, "Signature error: {}", e),
             CoseError::UnimplementedError => write!(f, "Not implemented"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,10 @@ use serde_cbor::Error as CborError;
 pub enum CoseError {
     /// Failed to generate random bytes
     RandomnessFailed(Box<dyn Error>),
+    /// Computation of a cryptographic hash failed
+    HashingError(Box<dyn Error>),
     /// Signature could not be performed due to OpenSSL error.
-    SignatureError(openssl::error::ErrorStack),
+    SignatureError(Box<dyn Error>),
     /// This feature is not yet fully implemented according
     /// to the spec.
     UnimplementedError,
@@ -37,6 +39,7 @@ impl fmt::Display for CoseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CoseError::RandomnessFailed(e) => write!(f, "Randomness error: {}", e),
+            CoseError::HashingError(e) => write!(f, "Hashing failed: {}", e),
             CoseError::SignatureError(e) => write!(f, "Signature error: {}", e),
             CoseError::UnimplementedError => write!(f, "Not implemented"),
             CoseError::UnsupportedError(e) => write!(f, "Not supported: {}", e),
@@ -55,7 +58,7 @@ impl fmt::Display for CoseError {
 impl Error for CoseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            CoseError::SignatureError(e) => Some(e),
+            CoseError::SignatureError(e) => e.source(),
             CoseError::SerializationError(e) => Some(e),
             _ => None,
         }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -564,7 +564,7 @@ mod tests {
 
     #[cfg(feature = "key_openssl_pkey")]
     mod openssl {
-        use crate::crypto::OpenSSL;
+        use crate::crypto::Openssl;
         use crate::crypto::SignatureAlgorithm;
         use crate::sign::*;
         use openssl::pkey::{PKey, Private, Public};
@@ -727,7 +727,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).unwrap(),
+                cose_doc.get_payload::<Openssl>(Some(&ec_public)).unwrap(),
                 TEXT
             );
         }
@@ -763,7 +763,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).unwrap(),
+                cose_doc.get_payload::<Openssl>(Some(&ec_public)).unwrap(),
                 TEXT
             );
         }
@@ -801,7 +801,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(
-                cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).unwrap(),
+                cose_doc.get_payload::<Openssl>(Some(&ec_public)).unwrap(),
                 TEXT
             );
         }
@@ -811,12 +811,12 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
-                cose_doc2.get_payload::<OpenSSL>(Some(&ec_public)).unwrap()
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
+                cose_doc2.get_payload::<Openssl>(Some(&ec_public)).unwrap()
             );
             assert!(!cose_doc2.get_unprotected().is_empty(),);
             assert_eq!(
@@ -831,7 +831,7 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
             // Tag 6.18 should be present
             assert_eq!(tagged_bytes[0], 6 << 5 | 18);
@@ -840,8 +840,8 @@ mod tests {
             let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
-                cose_doc2.get_payload::<OpenSSL>(Some(&ec_public)).unwrap()
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
+                cose_doc2.get_payload::<Openssl>(Some(&ec_public)).unwrap()
             );
         }
 
@@ -851,15 +851,15 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
             // Tag 6.18 should be present
             assert_eq!(tagged_bytes[0], 6 << 5 | 18);
             let cose_doc2: CoseSign1 = serde_cbor::from_slice(&tagged_bytes).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
-                cose_doc2.get_payload::<OpenSSL>(Some(&ec_public)).unwrap()
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
+                cose_doc2.get_payload::<Openssl>(Some(&ec_public)).unwrap()
             );
         }
 
@@ -877,7 +877,7 @@ mod tests {
             let mut unprotected = HeaderMap::new();
             unprotected.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new_with_protected::<OpenSSL>(
+            let cose_doc1 = CoseSign1::new_with_protected::<Openssl>(
                 TEXT,
                 &protected,
                 &unprotected,
@@ -887,7 +887,7 @@ mod tests {
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
 
             let (protected, payload) = cose_doc2
-                .get_protected_and_payload::<OpenSSL>(Some(&ec_public))
+                .get_protected_and_payload::<Openssl>(Some(&ec_public))
                 .unwrap();
 
             assert_eq!(
@@ -907,12 +907,12 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
-                cose_doc2.get_payload::<OpenSSL>(Some(&ec_public)).unwrap()
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
+                cose_doc2.get_payload::<Openssl>(Some(&ec_public)).unwrap()
             );
         }
 
@@ -922,16 +922,16 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(Some(&ec_public)).unwrap(),
+                cose_doc1.get_payload::<Openssl>(Some(&ec_public)).unwrap(),
                 TEXT.to_vec()
             );
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
-                cose_doc2.get_payload::<OpenSSL>(Some(&ec_public)).unwrap()
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
+                cose_doc2.get_payload::<Openssl>(Some(&ec_public)).unwrap()
             );
         }
 
@@ -941,7 +941,7 @@ mod tests {
             let ec_private = openssl::ec::EcKey::generate(&alg).unwrap();
             let ec_private = PKey::from_ec_key(ec_private).unwrap();
             let map = HeaderMap::new();
-            let result = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private);
+            let result = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private);
             assert!(result.is_err());
         }
 
@@ -952,11 +952,11 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
 
-            assert!(cose_doc1.verify_signature::<OpenSSL>(&ec_public).unwrap());
+            assert!(cose_doc1.verify_signature::<Openssl>(&ec_public).unwrap());
             assert!(!cose_doc1
-                .verify_signature::<OpenSSL>(&ec_public_other)
+                .verify_signature::<Openssl>(&ec_public_other)
                 .unwrap());
         }
 
@@ -967,11 +967,11 @@ mod tests {
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
 
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &ec_private).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
 
-            assert!(cose_doc1.verify_signature::<OpenSSL>(&ec_public).unwrap());
+            assert!(cose_doc1.verify_signature::<Openssl>(&ec_public).unwrap());
             assert!(!cose_doc1
-                .verify_signature::<OpenSSL>(&ec_public_other)
+                .verify_signature::<Openssl>(&ec_public_other)
                 .unwrap());
         }
 
@@ -1002,7 +1002,7 @@ mod tests {
             ])
             .unwrap();
 
-            assert!(cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).is_err());
+            assert!(cose_doc.get_payload::<Openssl>(Some(&ec_public)).is_err());
         }
 
         #[test]
@@ -1032,7 +1032,7 @@ mod tests {
             ])
             .unwrap();
 
-            assert!(cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).is_err());
+            assert!(cose_doc.get_payload::<Openssl>(Some(&ec_public)).is_err());
         }
 
         #[test]
@@ -1146,7 +1146,7 @@ mod tests {
             let ec_public = rfc_8152_key_kid_11();
 
             assert_eq!(
-                cose_doc.get_payload::<OpenSSL>(Some(&ec_public)).unwrap(),
+                cose_doc.get_payload::<Openssl>(Some(&ec_public)).unwrap(),
                 payload
             );
         }
@@ -1156,7 +1156,7 @@ mod tests {
     mod tpm {
         use super::TEXT;
         use crate::crypto::tpm::TpmKey;
-        use crate::crypto::OpenSSL;
+        use crate::crypto::Openssl;
         use crate::sign::*;
 
         use tss_esapi::{
@@ -1213,7 +1213,7 @@ mod tests {
 
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &mut tpm_key).unwrap();
+            let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &mut tpm_key).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
 
             // Tag 6.18 should be present
@@ -1221,9 +1221,9 @@ mod tests {
             let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
 
             assert_eq!(
-                cose_doc1.get_payload::<OpenSSL>(None).unwrap(),
+                cose_doc1.get_payload::<Openssl>(None).unwrap(),
                 cose_doc2
-                    .get_payload::<OpenSSL>(Some(&mut tpm_key))
+                    .get_payload::<Openssl>(Some(&mut tpm_key))
                     .unwrap()
             );
         }
@@ -1271,7 +1271,7 @@ mod tests {
 
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-            let mut cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &mut tpm_key).unwrap();
+            let mut cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &mut tpm_key).unwrap();
 
             // Mangle the signature
             cose_doc1.signature[0] = 0;
@@ -1279,7 +1279,7 @@ mod tests {
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
 
-            match cose_doc2.get_payload::<OpenSSL>(Some(&mut tpm_key)) {
+            match cose_doc2.get_payload::<Openssl>(Some(&mut tpm_key)) {
                 Ok(_) => panic!("Did not fail"),
                 Err(CoseError::UnverifiedSignature) => {}
                 Err(e) => {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1155,7 +1155,9 @@ mod tests {
     #[cfg(feature = "key_tpm")]
     mod tpm {
         use super::TEXT;
-        use crate::{crypto::tpm::TpmKey, sign::*};
+        use crate::crypto::tpm::TpmKey;
+        use crate::crypto::OpenSSL;
+        use crate::sign::*;
 
         use tss_esapi::{
             attributes::SessionAttributesBuilder,
@@ -1211,7 +1213,7 @@ mod tests {
 
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-            let cose_doc1 = CoseSign1::new(TEXT, &map, &mut tpm_key).unwrap();
+            let cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &mut tpm_key).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
 
             // Tag 6.18 should be present
@@ -1269,7 +1271,7 @@ mod tests {
 
             let mut map = HeaderMap::new();
             map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
-            let mut cose_doc1 = CoseSign1::new(TEXT, &map, &mut tpm_key).unwrap();
+            let mut cose_doc1 = CoseSign1::new::<OpenSSL>(TEXT, &map, &mut tpm_key).unwrap();
 
             // Mangle the signature
             cose_doc1.signature[0] = 0;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -8,7 +8,9 @@ use serde_cbor::Error as CborError;
 use serde_cbor::Value as CborValue;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::crypto::{Hash, MessageDigest, SigningPrivateKey, SigningPublicKey};
+#[cfg(feature = "openssl")]
+use crate::crypto::MessageDigest;
+use crate::crypto::{Hash, SigningPrivateKey, SigningPublicKey};
 use crate::error::CoseError;
 use crate::header_map::{map_to_empty_or_serialized, HeaderMap};
 
@@ -25,6 +27,7 @@ pub enum SignatureAlgorithm {
 }
 
 impl SignatureAlgorithm {
+    #[cfg(feature = "openssl")]
     pub(crate) fn key_length(&self) -> usize {
         match self {
             SignatureAlgorithm::ES256 => 32,
@@ -34,6 +37,7 @@ impl SignatureAlgorithm {
         }
     }
 
+    #[cfg(feature = "openssl")]
     pub(crate) fn suggested_message_digest(&self) -> MessageDigest {
         match self {
             SignatureAlgorithm::ES256 => MessageDigest::Sha256,


### PR DESCRIPTION
*Issue #, if available:*
No issue number

*Description of changes:*
Not all platforms may want to rely on OpenSSL for cryptographic operations. This PR abstracts the implementation. Users can still choose to rely on OpenSSL (this is the default), but can just as easily provide their own cryptographic implementation. This PR is similar to #28 but uses dependency injection using traits to ensure features remain additive, as a reviewer requested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
