### PR TITLE
enable KMS key testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,21 +8,30 @@ on:
     branches:
       - main
 
-
 env:
     RUSTFLAGS: -Dwarnings
+    AWS_KMS_TEST_KEY_ARN: arn:aws:kms:us-east-1:667861386598:key/d7da2f8d-2bdf-4c62-963f-16c921522fee
+    TEST_KEY_SIG_ALG: ES384
 
 jobs:
     test:
         name: Test on rust ${{matrix.rust}}  (keys ${{ matrix.key_feature_set }})
         runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
         strategy:
             matrix:
                 rust: [1.58.1, stable, nightly]
                 key_feature_set:
                   - key_openssl_pkey
+                  - key_kms
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
+        - uses: aws-actions/configure-aws-credentials@v1
+          with:
+            role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
+            aws-region: us-east-1
         - uses: dtolnay/rust-toolchain@master
           with:
               toolchain: ${{matrix.rust}}


### PR DESCRIPTION
The tests fail on this PR, because secrets and Oidc tokens are unavailable to workflows which are changed or added, for security reasons. Once merged, this will  be able to pull the AWS_TEST_ROLE_ARN from the github secrets store (although this doesn't really need to be secret) and when creating a PR, the Oidc token will try to use the claim `repo:awslabs/aws-nitro-enclaves-cose:pull_request` for pre-approved workflows. I've tested this on my private repo and it seemed to work as advertised.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
