### PR TITLE
ci: use env instead of secret variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
     RUSTFLAGS: -Dwarnings
     AWS_KMS_TEST_KEY_ARN: arn:aws:kms:us-east-1:667861386598:key/d7da2f8d-2bdf-4c62-963f-16c921522fee
+    AWS_KMS_TEST_ROLE_ARN: arn:aws:iam::667861386598:role/aws-nitro-enclaves-cose-tests
     TEST_KEY_SIG_ALG: ES384
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: aws-actions/configure-aws-credentials@v1
           with:
-            role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
+            role-to-assume: ${{ env.AWS_KMS_TEST_ROLE_ARN }}
             aws-region: us-east-1
         - uses: dtolnay/rust-toolchain@master
           with:


### PR DESCRIPTION
It seems like the CI doesn't allow any PR to access the secrets store.
Since the Role Arn is not really a secret and the role itself is scoped
down to access the test key and nothing else, there is limited risk in
having it available as an env variable, but should hopefully allow for
testing PRs, although it does make setting up testing in a fork slightly
more challenging.

Signed-off-by: Petre Eftime <epetre@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
