### PR TITLE
Fix serde build errors after update

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -62,8 +62,10 @@ pub struct SigStructure(
     #[serde(skip_serializing_if = "Option::is_none")]
     Option<ByteBuf>,
     /// external_aad : bstr,
+    #[serde(default)]
     ByteBuf,
     /// payload : bstr
+    #[serde(default)]
     ByteBuf,
 );
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issues with serde after update to unblock serde update in `aws-nitro-enclaves-cli` repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
