### PR TITLE
README: Update build status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![status]][actions] [![version]][crates.io] [![docs]][docs.rs] ![msrv]
 
-[status]: https://img.shields.io/github/workflow/status/awslabs/aws-nitro-enclaves-cose/CI/master
+[status]: https://img.shields.io/github/actions/workflow/status/awslabs/aws-nitro-enclaves-cose/ci.yml?branch=main
 [actions]: https://github.com/awslabs/aws-nitro-enclaves-cose/actions?query=branch%3Amain
 [version]: https://img.shields.io/crates/v/aws-nitro-enclaves-cose.svg
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-cose


### PR DESCRIPTION
The badges URL has changed (see
https://github.com/badges/shields/issues/8671), update README accordingly.

*Issue #, if available:* N/A

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
