### PR TITLE
Dependabot/cargo/aws config 0.101

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                rust: [1.67, stable, nightly]
+                rust: [1.70.0, stable, nightly]
                 key_feature_set:
                   - key_openssl_pkey
                   - key_kms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "6.1", optional = true }
-aws-config = { version = "0.56", optional = true }
+aws-config = { version = "0.101", features = ["behavior-version-latest"], optional = true }
 aws-sdk-kms = { version = "0.31", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["COSE"]
 categories = ["cryptography"]
 repository = "https://github.com/awslabs/aws-nitro-enclaves-cose"
 description = "This library aims to provide a safe Rust implementation of COSE, with COSE Sign1 currently implemented."
-rust-version = "1.67"
+rust-version = "1.70"
 
 [dependencies]
 serde_cbor = { version="0.11", features = ["tags"] }
@@ -18,7 +18,7 @@ serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "6.1", optional = true }
 aws-config = { version = "0.101", features = ["behavior-version-latest"], optional = true }
-aws-sdk-kms = { version = "0.31", optional = true }
+aws-sdk-kms = { version = "0.38", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 
 [dependencies.serde]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-cose
 [docs]: https://img.shields.io/docsrs/aws-nitro-enclaves-cose
 [docs.rs]: https://docs.rs/aws-nitro-enclaves-cose
-[msrv]: https://img.shields.io/badge/MSRV-1.67.1-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.70.0-blue
 
 ## COSE for AWS Nitro Enclaves
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
https://github.com/awslabs/aws-nitro-enclaves-cose/pull/78 and https://github.com/awslabs/aws-nitro-enclaves-cose/pull/79 had to be done in lockstep for it to work.
Additionally, aws-config introduced a breaking change where behavior-version-latest feature needs to be used when constructing the SdkConfig struct.
Finally, MSRV needs to be updated to 1.70.0 as aws-smithy-runtime (a dependency of aws-sdk-kms) needs 1.70 to compile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
