### PR TITLE
Downgrade KMS SDK to avoid conflicts with TSS dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Petre Eftime <epetre@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,8 +17,7 @@ serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "7.4", optional = true }
-aws-config = { version = "0.56", optional = true }
-aws-sdk-kms = { version = "0.31", optional = true }
+aws-sdk-kms = { version = "0.28", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 
 [dependencies.serde]
@@ -27,9 +26,10 @@ features = ["derive"]
 
 [dev-dependencies]
 hex = "0.4"
+aws-config = { version = "0.55" }
 
 [features]
 default = ["key_openssl_pkey"]
 key_openssl_pkey = ["openssl"]
 key_tpm = ["tss-esapi", "openssl"]
-key_kms = ["aws-config", "aws-sdk-kms", "tokio", "key_openssl_pkey"]
+key_kms = ["aws-sdk-kms", "tokio", "key_openssl_pkey"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In the latest version aws-sdk-kms and tss-esapi has a common conflicting transitive dependency. Each of the libraries has different version requirements for that dependency and they don't intersect (Originated from `tss-esapi`->`mbox` versioning hard requirements as described [here](https://github.com/parallaxsecond/rust-tss-esapi/issues/519)).

To make build successful we align it and downgrade aws-sdk-kms to the version where conflict disappears.

Also aws-config dependency is used only for testing and is moved to dev dependencies.

Bumping up the successfully buildable package version to publish it to crates.io

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
