### PR TITLE
Update dependencies and bump new version of the crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                rust: [1.67, stable, nightly]
+                rust: [1.68.2, stable, nightly]
                 key_feature_set:
                   - key_openssl_pkey
                   - key_kms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["COSE"]
 categories = ["cryptography"]
 repository = "https://github.com/awslabs/aws-nitro-enclaves-cose"
 description = "This library aims to provide a safe Rust implementation of COSE, with COSE Sign1 currently implemented."
-rust-version = "1.67"
+rust-version = "1.68"
 
 [dependencies]
 serde_cbor = { version="0.11", features = ["tags"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Petre Eftime <epetre@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,9 +16,8 @@ serde_repr = "0.1"
 serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
-tss-esapi = { version = "7.4", optional = true }
-aws-config = { version = "0.56", optional = true }
-aws-sdk-kms = { version = "0.31", optional = true }
+tss-esapi = { version = "7.5.1", optional = true }
+aws-sdk-kms = { version = "<=1.20", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 
 [dependencies.serde]
@@ -27,9 +26,11 @@ features = ["derive"]
 
 [dev-dependencies]
 hex = "0.4"
+aws-config = { version = "<=1.1" }
+aws-smithy-runtime = { version = "<=1.2" }
 
 [features]
 default = ["key_openssl_pkey"]
 key_openssl_pkey = ["openssl"]
 key_tpm = ["tss-esapi", "openssl"]
-key_kms = ["aws-config", "aws-sdk-kms", "tokio", "key_openssl_pkey"]
+key_kms = ["aws-sdk-kms", "tokio", "key_openssl_pkey"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-cose
 [docs]: https://img.shields.io/docsrs/aws-nitro-enclaves-cose
 [docs.rs]: https://docs.rs/aws-nitro-enclaves-cose
-[msrv]: https://img.shields.io/badge/MSRV-1.67.1-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.68.2-blue
 
 ## COSE for AWS Nitro Enclaves
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1312,11 +1312,12 @@ mod tests {
             sign::*,
         };
 
+        use aws_config::BehaviorVersion;
         use std::env;
 
         #[tokio::test]
         async fn cose_sign_kms() {
-            let config = aws_config::from_env().load().await;
+            let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
             let kms_client = aws_sdk_kms::Client::new(&config);
 
             tokio::task::spawn_blocking(|| {
@@ -1350,7 +1351,7 @@ mod tests {
 
         #[tokio::test]
         async fn cose_sign_kms_invalid_signature() {
-            let config = aws_config::from_env().load().await;
+            let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
             let kms_client = aws_sdk_kms::Client::new(&config);
 
             tokio::task::spawn_blocking(|| {
@@ -1388,7 +1389,7 @@ mod tests {
         #[cfg(feature = "key_openssl_pkey")]
         #[tokio::test]
         async fn cose_sign_kms_public_key() {
-            let config = aws_config::from_env().load().await;
+            let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
             let kms_client = aws_sdk_kms::Client::new(&config);
 
             let key_id = env::var("AWS_KMS_TEST_KEY_ARN").expect("Please set AWS_KMS_TEST_KEY_ARN");
@@ -1418,7 +1419,7 @@ mod tests {
         #[cfg(feature = "key_openssl_pkey")]
         #[tokio::test]
         async fn cose_sign_kms_public_key_invalid_signature() {
-            let config = aws_config::from_env().load().await;
+            let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
             let kms_client = aws_sdk_kms::Client::new(&config);
 
             let key_id = env::var("AWS_KMS_TEST_KEY_ARN").expect("Please set AWS_KMS_TEST_KEY_ARN");


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Bump `tss-esapi` to the latest version to get rid of dependencies conflicts with KMS SDK
  (More details in https://github.com/parallaxsecond/rust-tss-esapi/issues/519)
* Bump AWS SDK dependencies to their latest versions (within possible MSRV=1.68.2 thus restricted with `<=`, otherwise not buildable)
* Move `aws-config` to `dev-dependencies` because it's used only in tests
* Bump MSRV to 1.68.2 (to sync it with [`aws-nitro-cli`](https://github.com/aws/aws-nitro-enclaves-cli/commit/a9cd74d1febcbd1609562d2af5fbd7c25c12dcb8)
* Bump the crate version itself

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
