### PR TITLE
Bump Rust version and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                rust: [1.68.2, stable, nightly]
+                rust: [1.71.1, stable, nightly]
                 key_feature_set:
                   - key_openssl_pkey
                   - key_kms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["COSE"]
 categories = ["cryptography"]
 repository = "https://github.com/awslabs/aws-nitro-enclaves-cose"
 description = "This library aims to provide a safe Rust implementation of COSE, with COSE Sign1 currently implemented."
-rust-version = "1.68"
+rust-version = "1.71"
 
 [dependencies]
 serde_cbor = { version="0.11", features = ["tags"] }
@@ -17,7 +17,7 @@ serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "7.5.1", optional = true }
-aws-sdk-kms = { version = "<=1.20", optional = true }
+aws-sdk-kms = { version = "<=1.22", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 
 [dependencies.serde]
@@ -26,8 +26,11 @@ features = ["derive"]
 
 [dev-dependencies]
 hex = "0.4"
-aws-config = { version = "<=1.1" }
-aws-smithy-runtime = { version = "<=1.2" }
+aws-config = { version = "<=1.5" }
+aws-sdk-sso = { version = "<= 1.21.0" }
+aws-sdk-ssooidc = { version = "<= 1.21.0" }
+aws-sdk-sts = { version = "<= 1.21.0" }
+aws-smithy-runtime = { version = "<=1.6" }
 
 [features]
 default = ["key_openssl_pkey"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-cose
 [docs]: https://img.shields.io/docsrs/aws-nitro-enclaves-cose
 [docs.rs]: https://docs.rs/aws-nitro-enclaves-cose
-[msrv]: https://img.shields.io/badge/MSRV-1.68.2-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.71.1-blue
 
 ## COSE for AWS Nitro Enclaves
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -208,14 +208,14 @@ impl FromStr for SignatureAlgorithm {
     }
 }
 
-impl ToString for SignatureAlgorithm {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for SignatureAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string_name = match self {
             SignatureAlgorithm::ES256 => "ES256",
             SignatureAlgorithm::ES384 => "ES384",
             SignatureAlgorithm::ES512 => "ES512",
-        }
-        .to_string()
+        };
+        write!(f, "{}", string_name)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This commit bumps MSRV to 1.71 and updates `aws-sdk-kms` with its dependencies like `aws-config`, and `aws-smithy-runtime`.

Additionally it fixes Clippy errors related to trait `ToString` vs `std::fmt::Display`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
