### PR TITLE
Update chagelog and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 
 # Changelog
 
+## 0.5.3
+* Bumped `aws-sdk-kms` to 1.22
+* Bumped MSRV to 1.71
+* Updated docstrings to mention the need in Tokio runtime for non-local key
+use-cases
+
+## 0.5.2
+* Bumped `serde_with` to 3.3
+* Bumped `tss-esapi` to 7.5
+* Bumped `aws-sdk-kms` to 1.20
+* Bumped MSRV to 1.68
+
+## 0.5.1
+* Fixed serde build errors after update
+
 ## 0.5.0
 * Support signing with an AWS KMS private key via the `key_kms` feature. (thank you @puiterwijk)
 * Abstract Openssl operations (thank you @raoulstrackx)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Petre Eftime <epetre@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the changelog and adds docstrings for methods `new_from_public_key`, `sign`, and `verify` for `KmsKey`s to specifically highlight the need to call these methods from a Tokio runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
