### PR TITLE
Migrate CBOR serialization from serde_cbor to ciborium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "aws-nitro-enclaves-cose"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Petre Eftime <epetre@amazon.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 keywords = ["COSE"]
 categories = ["cryptography"]
 repository = "https://github.com/awslabs/aws-nitro-enclaves-cose"
 description = "This library aims to provide a safe Rust implementation of COSE, with COSE Sign1 currently implemented."
-rust-version = "1.71"
+rust-version = "1.91.1"
 
 [dependencies]
-serde_cbor = { version="0.11", features = ["tags"] }
+ciborium = "0.2"
 serde_repr = "0.1"
 serde_bytes = { version = "0.11", features = ["std"] }
 serde_with = { version = "3.3" }
 openssl = { version = "0.10", optional = true }
 tss-esapi = { version = "7.5.1", optional = true }
-aws-sdk-kms = { version = "<=1.22", optional = true }
+aws-sdk-kms = { version = "1", optional = true }
 tokio = { version = "1.20", features = ["rt", "macros"], optional = true }
 
 [dependencies.serde]
@@ -26,11 +26,11 @@ features = ["derive"]
 
 [dev-dependencies]
 hex = "0.4"
-aws-config = { version = "<=1.5" }
-aws-sdk-sso = { version = "<= 1.21.0" }
-aws-sdk-ssooidc = { version = "<= 1.21.0" }
-aws-sdk-sts = { version = "<= 1.21.0" }
-aws-smithy-runtime = { version = "<=1.6" }
+aws-config = { version = "1" }
+aws-sdk-sso = { version = "1" }
+aws-sdk-ssooidc = { version = "1" }
+aws-sdk-sts = { version = "1" }
+aws-smithy-runtime = { version = "1" }
 
 [features]
 default = ["key_openssl_pkey"]

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -1,0 +1,13 @@
+use crate::error::CoseError;
+use serde::{de::DeserializeOwned, Serialize};
+
+pub(crate) fn from_slice<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, CoseError> {
+    ciborium::de::from_reader(bytes).map_err(|e| CoseError::SerializationError(Box::new(e)))
+}
+
+pub(crate) fn to_vec<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, CoseError> {
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(value, &mut buf)
+        .map_err(|e| CoseError::SerializationError(Box::new(e)))?;
+    Ok(buf)
+}

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,12 +1,12 @@
 //! COSE Encryption
-use serde::{ser::SerializeSeq, Deserialize, Serialize, Serializer};
+use ciborium::tag::Captured;
+use ciborium::value::{Integer, Value as CborValue};
+use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
-use serde_cbor::Error as CborError;
-use serde_cbor::Value as CborValue;
 
 use crate::crypto::{Decryption, Encryption, Entropy};
 use crate::error::CoseError;
-use crate::header_map::{map_to_empty_or_serialized, HeaderMap};
+use crate::header_map::{map_to_empty_or_serialized, validate_protected_bytes, HeaderMap};
 
 const KTY: i8 = 1;
 const IV: i8 = 5;
@@ -143,7 +143,7 @@ impl Serialize for EncStructure {
 }
 
 impl EncStructure {
-    fn new_encrypt0(protected: &[u8]) -> Result<Self, CborError> {
+    fn new_encrypt0(protected: &[u8]) -> Result<Self, CoseError> {
         Ok(EncStructure {
             context: String::from("Encrypt0"),
             protected: ByteBuf::from(protected.to_vec()),
@@ -153,8 +153,8 @@ impl EncStructure {
 
     /// Serializes the EncStructure to . We don't care about deserialization, since
     /// both sides are supposed to compute the EncStructure and compare.
-    fn as_bytes(&self) -> Result<Vec<u8>, CborError> {
-        serde_cbor::to_vec(self)
+    fn as_bytes(&self) -> Result<Vec<u8>, CoseError> {
+        crate::cbor::to_vec(self)
     }
 }
 
@@ -191,7 +191,7 @@ impl EncStructure {
 ///      Headers,
 ///      ciphertext : bstr / nil,
 ///  ]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct CoseEncrypt0 {
     /// protected: empty_or_serialized_map,
     protected: ByteBuf,
@@ -201,6 +201,51 @@ pub struct CoseEncrypt0 {
     /// The spec allows ciphertext to be nil and transported separately, but it's not useful at the
     /// moment, so this is just a ByteBuf for simplicity.
     ciphertext: ByteBuf,
+}
+
+impl<'de> Deserialize<'de> for CoseEncrypt0 {
+    fn deserialize<D>(deserializer: D) -> Result<CoseEncrypt0, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, SeqAccess, Visitor};
+        use std::fmt;
+
+        struct CoseEncrypt0Visitor;
+
+        impl<'de> Visitor<'de> for CoseEncrypt0Visitor {
+            type Value = CoseEncrypt0;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a CoseEncrypt0 3-element sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<CoseEncrypt0, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let protected = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("protected")),
+                };
+                let unprotected = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("unprotected")),
+                };
+                let ciphertext = match seq.next_element()? {
+                    Some(v) => v,
+                    None => return Err(A::Error::missing_field("ciphertext")),
+                };
+                Ok(CoseEncrypt0 {
+                    protected,
+                    unprotected,
+                    ciphertext,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(CoseEncrypt0Visitor)
+    }
 }
 
 impl Serialize for CoseEncrypt0 {
@@ -237,24 +282,20 @@ impl CoseEncrypt0 {
 
         let cose_alg_value = cose_alg.value();
         let mut protected = HeaderMap::new();
-        protected.insert(KTY.into(), CborValue::Integer(cose_alg_value as i128));
+        protected.insert(KTY.into(), CborValue::Integer(Integer::from(cose_alg_value)));
         let mut unprotected = HeaderMap::new();
         unprotected.insert(IV.into(), CborValue::Bytes(iv.to_owned()));
 
-        let protected_bytes =
-            map_to_empty_or_serialized(&protected).map_err(CoseError::SerializationError)?;
+        let protected_bytes = map_to_empty_or_serialized(&protected)?;
 
-        let enc_structure =
-            EncStructure::new_encrypt0(&protected_bytes).map_err(CoseError::SerializationError)?;
+        let enc_structure = EncStructure::new_encrypt0(&protected_bytes)?;
 
         let mut tag = vec![0; cose_alg.tag_size()];
         let mut ciphertext = C::encrypt_aead(
             cose_alg.into(),
             key,
             Some(&iv[..]),
-            &enc_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
+            &enc_structure.as_bytes()?,
             payload,
             &mut tag,
         )
@@ -276,10 +317,9 @@ impl CoseEncrypt0 {
         &self,
         key: &[u8],
     ) -> Result<(HeaderMap, &HeaderMap, Vec<u8>), CoseError> {
-        let protected: HeaderMap =
-            HeaderMap::from_bytes(&self.protected).map_err(CoseError::SerializationError)?;
+        let protected: HeaderMap = HeaderMap::from_bytes(&self.protected)?;
 
-        let protected_enc_alg = match protected.get(&CborValue::Integer(1)) {
+        let protected_enc_alg = match protected.get(&CborValue::Integer(Integer::from(1_i32))) {
             Some(CborValue::Integer(val)) => val,
             _ => {
                 return Err(CoseError::SpecificationError(
@@ -289,22 +329,18 @@ impl CoseEncrypt0 {
             }
         };
 
-        let cose_alg = match CoseAlgorithm::from_value(*protected_enc_alg as i8) {
-            Some(v) => v,
-            None => {
-                return Err(CoseError::UnsupportedError(
-                    "Unsupported encryption algorithm".to_string(),
-                ))
-            }
-        };
+        let cose_alg = i8::try_from(i128::from(*protected_enc_alg))
+            .ok()
+            .and_then(CoseAlgorithm::from_value)
+            .ok_or_else(|| {
+                CoseError::UnsupportedError("Unsupported encryption algorithm".to_string())
+            })?;
 
-        let protected_bytes =
-            map_to_empty_or_serialized(&protected).map_err(CoseError::SerializationError)?;
+        let protected_bytes = map_to_empty_or_serialized(&protected)?;
 
-        let enc_structure =
-            EncStructure::new_encrypt0(&protected_bytes).map_err(CoseError::SerializationError)?;
+        let enc_structure = EncStructure::new_encrypt0(&protected_bytes)?;
 
-        let iv = match self.unprotected.get(&CborValue::Integer(5)) {
+        let iv = match self.unprotected.get(&CborValue::Integer(Integer::from(5_i32))) {
             Some(CborValue::Bytes(val)) => val,
             _ => {
                 return Err(CoseError::SpecificationError(
@@ -321,9 +357,7 @@ impl CoseEncrypt0 {
             cose_alg.into(),
             key,
             Some(iv),
-            &enc_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
+            &enc_structure.as_bytes()?,
             ciphertext,
             tag,
         )
@@ -335,28 +369,24 @@ impl CoseEncrypt0 {
     /// Serializes the structure for transport / storage. If `tagged` is true, the optional #6.16
     /// tag is added to the output.
     pub fn as_bytes(&self, tagged: bool) -> Result<Vec<u8>, CoseError> {
-        let bytes = if tagged {
-            serde_cbor::to_vec(&serde_cbor::tags::Tagged::new(Some(16), &self))
+        if tagged {
+            crate::cbor::to_vec(&ciborium::tag::Required::<_, 16>(self))
         } else {
-            serde_cbor::to_vec(&self)
-        };
-        bytes.map_err(CoseError::SerializationError)
+            crate::cbor::to_vec(self)
+        }
     }
 
-    /// This function deserializes the structure, but doesn't check the contents for correctness
-    /// at all. Accepts untagged structures or structures with tag 16.
+    /// Deserializes a `CoseEncrypt0` from bytes. Accepts untagged structures or structures
+    /// tagged with 16. Validates that the protected header is a well-formed CBOR map.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CoseError> {
-        let coseencrypt0: serde_cbor::tags::Tagged<Self> =
-            serde_cbor::from_slice(bytes).map_err(CoseError::SerializationError)?;
-
-        match coseencrypt0.tag {
-            None | Some(16) => (),
-            Some(tag) => return Err(CoseError::TagError(Some(tag))),
+        let captured: Captured<CoseEncrypt0> = crate::cbor::from_slice(bytes)?;
+        match captured.0 {
+            None | Some(16) => {
+                validate_protected_bytes(captured.1.protected.as_slice())?;
+                Ok(captured.1)
+            }
+            Some(tag) => Err(CoseError::TagError(Some(tag))),
         }
-        let protected = coseencrypt0.value.protected.as_slice();
-        let _: HeaderMap =
-            serde_cbor::from_slice(protected).map_err(CoseError::SerializationError)?;
-        Ok(coseencrypt0.value)
     }
 }
 
@@ -375,14 +405,14 @@ mod tests {
         assert_eq!(dec, plaintext);
         assert_ne!(
             plaintext.to_vec(),
-            serde_cbor::to_vec(&cencrypt0.ciphertext).unwrap()
+            crate::cbor::to_vec(&cencrypt0.ciphertext).unwrap()
         );
         let fromb = CoseEncrypt0::from_bytes(&cencrypt0.as_bytes(true).unwrap()[..]).unwrap();
         let (_, _, dec) = fromb.decrypt::<Openssl>(key).unwrap();
         assert_eq!(dec, plaintext);
         assert_ne!(
             plaintext.to_vec(),
-            serde_cbor::to_vec(&fromb.ciphertext).unwrap()
+            crate::cbor::to_vec(&fromb.ciphertext).unwrap()
         );
     }
 
@@ -405,9 +435,7 @@ mod tests {
             CoseEncrypt0::new::<Openssl>(plaintext, CipherConfiguration::Gcm, key).unwrap();
         let mut protected = HeaderMap::new();
         protected.insert(KTY.into(), CborValue::Text("invalid".to_string()));
-        let protected_bytes = map_to_empty_or_serialized(&protected)
-            .map_err(CoseError::SerializationError)
-            .unwrap();
+        let protected_bytes = map_to_empty_or_serialized(&protected).unwrap();
         cencrypt0.protected = ByteBuf::from(protected_bytes);
         match cencrypt0.decrypt::<Openssl>(key).unwrap_err() {
             CoseError::SpecificationError(_) => (),
@@ -422,10 +450,8 @@ mod tests {
         let mut cencrypt0 =
             CoseEncrypt0::new::<Openssl>(plaintext, CipherConfiguration::Gcm, key).unwrap();
         let mut protected = HeaderMap::new();
-        protected.insert(KTY.into(), CborValue::Integer(42));
-        let protected_bytes = map_to_empty_or_serialized(&protected)
-            .map_err(CoseError::SerializationError)
-            .unwrap();
+        protected.insert(KTY.into(), CborValue::Integer(Integer::from(42_i32)));
+        let protected_bytes = map_to_empty_or_serialized(&protected).unwrap();
         cencrypt0.protected = ByteBuf::from(protected_bytes);
         match cencrypt0.decrypt::<Openssl>(key).unwrap_err() {
             CoseError::UnsupportedError(_) => (),
@@ -440,7 +466,7 @@ mod tests {
         let mut cencrypt0 =
             CoseEncrypt0::new::<Openssl>(plaintext, CipherConfiguration::Gcm, key).unwrap();
         let mut unprotected = HeaderMap::new();
-        unprotected.insert(IV.into(), CborValue::Integer(42));
+        unprotected.insert(IV.into(), CborValue::Integer(Integer::from(42_i32)));
         cencrypt0.unprotected = unprotected;
         match cencrypt0.decrypt::<Openssl>(key).unwrap_err() {
             CoseError::SpecificationError(_) => (),

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,6 @@
 use std::error::Error;
 use std::fmt;
 
-use serde_cbor::Error as CborError;
-
 #[cfg(feature = "key_kms")]
 use aws_sdk_kms::{
     error::SdkError, operation::get_public_key::GetPublicKeyError, operation::sign::SignError,
@@ -31,7 +29,7 @@ pub enum CoseError {
     /// Deserialized structure does not respect the COSE specification.
     SpecificationError(String),
     /// Error while serializing or deserializing structures.
-    SerializationError(CborError),
+    SerializationError(Box<dyn Error + Send + Sync>),
     /// Tag is missing or incorrect.
     TagError(Option<u64>),
     /// Encryption could not be performed due to OpenSSL error.
@@ -80,7 +78,7 @@ impl Error for CoseError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             CoseError::SignatureError(e) => e.source(),
-            CoseError::SerializationError(e) => Some(e),
+            CoseError::SerializationError(e) => Some(e.as_ref()),
             _ => None,
         }
     }

--- a/src/header_map.rs
+++ b/src/header_map.rs
@@ -1,15 +1,22 @@
 //! COSE HeaderMap
 
+use ciborium::value::{CanonicalValue, Value};
 use serde::{Deserialize, Serialize};
-use serde_cbor::Error as CborError;
-use serde_cbor::Value as CborValue;
 use std::collections::BTreeMap;
+
+use crate::error::CoseError;
+
+/// Re-export of `ciborium::value::Value` for use in header map keys and values.
+pub use ciborium::value::Value as CborValue;
+
+/// Re-export of `ciborium::value::Integer` for constructing `CborValue::Integer` variants.
+pub use ciborium::value::Integer as CborInteger;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 /// Implementation of header_map, with CborValue keys and CborValue values.
 pub struct HeaderMap(
     #[serde(deserialize_with = "::serde_with::rust::maps_duplicate_key_is_error::deserialize")]
-    BTreeMap<CborValue, CborValue>,
+    BTreeMap<CanonicalValue, Value>,
 );
 
 impl HeaderMap {
@@ -21,12 +28,13 @@ impl HeaderMap {
     /// Inserts an element into HeaderMap. Both key and value are CborValue.
     /// If key already has a value, that value is returned.
     pub fn insert(&mut self, key: CborValue, value: CborValue) -> Option<CborValue> {
-        self.0.insert(key, value)
+        self.0.insert(CanonicalValue::from(key), value)
     }
 
     /// Returns the element at key.
     pub fn get(&self, key: &CborValue) -> Option<&CborValue> {
-        self.0.get(key)
+        // CanonicalValue does not implement Borrow<Value>, so we must clone the key on every lookup.
+        self.0.get(&CanonicalValue::from(key.clone()))
     }
 
     /// Returns true if HeaderMap has no elements, false otherwise.
@@ -35,15 +43,20 @@ impl HeaderMap {
     }
 
     /// Parses a slice of bytes into a HeaderMap, if possible.
-    pub fn from_bytes(header_map: &[u8]) -> Result<Self, CborError> {
-        serde_cbor::from_slice(header_map)
+    pub fn from_bytes(header_map: &[u8]) -> Result<Self, CoseError> {
+        crate::cbor::from_slice(header_map)
     }
 }
 
-pub(crate) fn map_to_empty_or_serialized(map: &HeaderMap) -> Result<Vec<u8>, CborError> {
+/// Validates that a byte slice deserializes as a well-formed CBOR header map.
+pub(crate) fn validate_protected_bytes(bytes: &[u8]) -> Result<(), CoseError> {
+    crate::cbor::from_slice::<HeaderMap>(bytes).map(|_| ())
+}
+
+pub(crate) fn map_to_empty_or_serialized(map: &HeaderMap) -> Result<Vec<u8>, CoseError> {
     if map.is_empty() {
         Ok(vec![])
     } else {
-        Ok(serde_cbor::to_vec(map)?)
+        crate::cbor::to_vec(map)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,12 @@
 #![deny(warnings)]
 
 //! This library aims to provide safe Rust implementations for COSE, using
-//! serde and serde_cbor as an encoding layer and OpenSSL as the base
+//! serde and ciborium as an encoding layer and OpenSSL as the base
 //! crypto library.
 //!
 //! Currently only COSE Sign1 and COSE Encrypt0 are implemented.
 
+pub(crate) mod cbor;
 pub mod crypto;
 pub mod encrypt;
 pub mod error;
@@ -15,5 +16,7 @@ pub mod sign;
 
 pub use crate::encrypt::CipherConfiguration;
 pub use crate::encrypt::CoseEncrypt0;
+pub use crate::header_map::CborInteger;
+pub use crate::header_map::CborValue;
 #[doc(inline)]
 pub use crate::sign::CoseSign1;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,13 +1,13 @@
 //! COSE Signing
 
+use ciborium::tag::Captured;
+use ciborium::value::{Integer, Value as CborValue};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::ByteBuf;
-use serde_cbor::Error as CborError;
-use serde_cbor::Value as CborValue;
 
 use crate::crypto::{Hash, SigningPrivateKey, SigningPublicKey};
 use crate::error::CoseError;
-use crate::header_map::{map_to_empty_or_serialized, HeaderMap};
+use crate::header_map::{map_to_empty_or_serialized, validate_protected_bytes, HeaderMap};
 
 ///  Implementation of the Sig_structure as defined in
 ///  [RFC8152](https://tools.ietf.org/html/rfc8152#section-4.4).
@@ -72,7 +72,7 @@ pub struct SigStructure(
 impl SigStructure {
     /// Takes the protected field of the COSE_Sign object and a raw slice of bytes as payload and creates a
     /// SigStructure for one signer from it
-    pub fn new_sign1(body_protected: &[u8], payload: &[u8]) -> Result<Self, CborError> {
+    pub fn new_sign1(body_protected: &[u8], payload: &[u8]) -> Result<Self, CoseError> {
         Ok(SigStructure(
             String::from("Signature1"),
             ByteBuf::from(body_protected.to_vec()),
@@ -87,14 +87,14 @@ impl SigStructure {
     pub fn new_sign1_cbor_value(
         body_protected: &[u8],
         payload: &CborValue,
-    ) -> Result<Self, CborError> {
-        Self::new_sign1(body_protected, &serde_cbor::to_vec(payload)?)
+    ) -> Result<Self, CoseError> {
+        Self::new_sign1(body_protected, &crate::cbor::to_vec(payload)?)
     }
 
     /// Serializes the SigStructure to . We don't care about deserialization, since
     /// both sides are supposed to compute the SigStructure and compare.
-    pub fn as_bytes(&self) -> Result<Vec<u8>, CborError> {
-        serde_cbor::to_vec(self)
+    pub fn as_bytes(&self) -> Result<Vec<u8>, CoseError> {
+        crate::cbor::to_vec(self)
     }
 }
 
@@ -164,9 +164,7 @@ impl SigStructure {
 ///   )
 ///
 ///   Note: Currently, the structures are not tagged, since it isn't required by
-///   the spec and the only way to achieve this is to add the token at the
-///   start of the serialized object, since the serde_cbor library doesn't
-///   support custom tags.
+///   the spec. Tagging can be enabled via the `tagged` parameter in `as_bytes`.
 #[derive(Debug, Clone)]
 pub struct CoseSign1 {
     /// protected: empty_or_serialized_map,
@@ -209,19 +207,17 @@ impl<'de> Deserialize<'de> for CoseSign1 {
             type Value = CoseSign1;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("a possibly tagged CoseSign1 structure")
+                f.write_str("a CoseSign1 4-element sequence")
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<CoseSign1, A::Error>
             where
                 A: SeqAccess<'de>,
             {
-                // This is the untagged version
                 let protected = match seq.next_element()? {
                     Some(v) => v,
                     None => return Err(A::Error::missing_field("protected")),
                 };
-
                 let unprotected = match seq.next_element()? {
                     Some(v) => v,
                     None => return Err(A::Error::missing_field("unprotected")),
@@ -234,7 +230,6 @@ impl<'de> Deserialize<'de> for CoseSign1 {
                     Some(v) => v,
                     None => return Err(A::Error::missing_field("signature")),
                 };
-
                 Ok(CoseSign1 {
                     protected,
                     unprotected,
@@ -242,17 +237,9 @@ impl<'de> Deserialize<'de> for CoseSign1 {
                     signature,
                 })
             }
-
-            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<CoseSign1, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                // This is the tagged version: we ignore the tag part, and just go into it
-                deserializer.deserialize_seq(CoseSign1Visitor)
-            }
         }
 
-        deserializer.deserialize_any(CoseSign1Visitor)
+        deserializer.deserialize_seq(CoseSign1Visitor)
     }
 }
 
@@ -285,17 +272,13 @@ impl CoseSign1 {
         let (_, digest) = key.get_parameters()?;
 
         // Create the SigStruct to sign
-        let protected_bytes =
-            map_to_empty_or_serialized(protected).map_err(CoseError::SerializationError)?;
+        let protected_bytes = map_to_empty_or_serialized(protected)?;
 
-        let sig_structure = SigStructure::new_sign1(&protected_bytes, payload)
-            .map_err(CoseError::SerializationError)?;
+        let sig_structure = SigStructure::new_sign1(&protected_bytes, payload)?;
 
         let struct_digest = H::hash(
             digest,
-            &sig_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
+            &sig_structure.as_bytes()?,
         )
         .map_err(|e| CoseError::SignatureError(Box::new(e)))?;
 
@@ -312,45 +295,38 @@ impl CoseSign1 {
     /// Serializes the structure for transport / storage. If `tagged` is true, the optional #6.18
     /// tag is added to the output.
     pub fn as_bytes(&self, tagged: bool) -> Result<Vec<u8>, CoseError> {
-        let bytes = if tagged {
-            serde_cbor::to_vec(&serde_cbor::tags::Tagged::new(Some(18), &self))
+        if tagged {
+            crate::cbor::to_vec(&ciborium::tag::Required::<_, 18>(self))
         } else {
-            serde_cbor::to_vec(&self)
-        };
-        bytes.map_err(CoseError::SerializationError)
+            crate::cbor::to_vec(self)
+        }
     }
 
-    /// This function deserializes the structure, but doesn't check the contents for correctness
-    /// at all. Accepts untagged structures or structures with tag 18.
+    /// Deserializes a `CoseSign1` from bytes. Accepts untagged structures or structures tagged
+    /// with 18. Validates that the protected header is a well-formed CBOR map.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CoseError> {
-        let cosesign1: serde_cbor::tags::Tagged<Self> =
-            serde_cbor::from_slice(bytes).map_err(CoseError::SerializationError)?;
-
-        match cosesign1.tag {
-            None | Some(18) => (),
-            Some(tag) => return Err(CoseError::TagError(Some(tag))),
+        let captured: Captured<CoseSign1> = crate::cbor::from_slice(bytes)?;
+        match captured.0 {
+            None | Some(18) => {
+                validate_protected_bytes(captured.1.protected.as_slice())?;
+                Ok(captured.1)
+            }
+            Some(other) => Err(CoseError::TagError(Some(other))),
         }
-        let protected = cosesign1.value.protected.as_slice();
-        let _: HeaderMap =
-            serde_cbor::from_slice(protected).map_err(CoseError::SerializationError)?;
-        Ok(cosesign1.value)
     }
 
-    /// This function deserializes the structure, but doesn't check the contents for correctness
-    /// at all. Accepts structures with tag 18.
+    /// Deserializes a `CoseSign1` from bytes. Requires tag 18 to be present.
+    /// Validates that the protected header is a well-formed CBOR map.
     pub fn from_bytes_tagged(bytes: &[u8]) -> Result<Self, CoseError> {
-        let cosesign1: serde_cbor::tags::Tagged<Self> =
-            serde_cbor::from_slice(bytes).map_err(CoseError::SerializationError)?;
-
-        match cosesign1.tag {
-            Some(18) => (),
-            other => return Err(CoseError::TagError(other)),
+        let captured: Captured<CoseSign1> = crate::cbor::from_slice(bytes)?;
+        match captured.0 {
+            Some(18) => {
+                validate_protected_bytes(captured.1.protected.as_slice())?;
+                Ok(captured.1)
+            }
+            Some(other) => Err(CoseError::TagError(Some(other))),
+            None => Err(CoseError::TagError(None)),
         }
-
-        let protected = cosesign1.value.protected.as_slice();
-        let _: HeaderMap =
-            serde_cbor::from_slice(protected).map_err(CoseError::SerializationError)?;
-        Ok(cosesign1.value)
     }
 
     /// This checks the signature included in the structure against the given public key and
@@ -373,10 +349,11 @@ impl CoseSign1 {
         // TODO: Currently this only validates the case where the Signature Algorithm is included
         // in the protected headers. To be compatible with other implementations this should be
         // more flexible, as stated in the spec.
-        let protected: HeaderMap =
-            HeaderMap::from_bytes(&self.protected).map_err(CoseError::SerializationError)?;
+        let protected: HeaderMap = HeaderMap::from_bytes(&self.protected)?;
 
-        if let Some(protected_signature_alg_val) = protected.get(&CborValue::Integer(1)) {
+        if let Some(protected_signature_alg_val) =
+            protected.get(&CborValue::Integer(Integer::from(1_i32)))
+        {
             let protected_signature_alg = match protected_signature_alg_val {
                 CborValue::Integer(val) => val,
                 _ => {
@@ -386,7 +363,7 @@ impl CoseSign1 {
                     ))
                 }
             };
-            if protected_signature_alg != &(signature_alg as i8 as i128) {
+            if *protected_signature_alg != Integer::from(signature_alg as i8) {
                 // The key doesn't match the one specified in the HeaderMap, so this fails
                 // signature verification immediately.
                 return Ok(false);
@@ -398,14 +375,11 @@ impl CoseSign1 {
             ));
         }
 
-        let sig_structure = SigStructure::new_sign1(&self.protected, &self.payload)
-            .map_err(CoseError::SerializationError)?;
+        let sig_structure = SigStructure::new_sign1(&self.protected, &self.payload)?;
 
         let struct_digest = H::hash(
             digest,
-            &sig_structure
-                .as_bytes()
-                .map_err(CoseError::SerializationError)?,
+            &sig_structure.as_bytes()?,
         )
         .map_err(|e| CoseError::SignatureError(Box::new(e)))?;
 
@@ -422,8 +396,7 @@ impl CoseSign1 {
         if key.is_some() && !self.verify_signature::<H>(key.unwrap())? {
             return Err(CoseError::UnverifiedSignature);
         }
-        let protected: HeaderMap =
-            HeaderMap::from_bytes(&self.protected).map_err(CoseError::SerializationError)?;
+        let protected: HeaderMap = HeaderMap::from_bytes(&self.protected)?;
         Ok((protected, self.payload.to_vec()))
     }
 
@@ -489,24 +462,24 @@ mod tests {
             // Check that HeaderMaps with duplicate entries emit error
             // {1: 42, 2: 42}
             let test = [0xa2, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A];
-            let map: HeaderMap = serde_cbor::from_slice(&test).unwrap();
+            let map: HeaderMap = crate::cbor::from_slice(&test).unwrap();
             assert_eq!(
-                map.get(&CborValue::Integer(1)),
-                Some(&CborValue::Integer(42))
+                map.get(&CborValue::Integer(Integer::from(1_i32))),
+                Some(&CborValue::Integer(Integer::from(42_i32)))
             );
             assert_eq!(
-                map.get(&CborValue::Integer(2)),
-                Some(&CborValue::Integer(42))
+                map.get(&CborValue::Integer(Integer::from(2_i32))),
+                Some(&CborValue::Integer(Integer::from(42_i32)))
             );
 
             // {1: 42, 2: 42, 1: 43}
             let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x01, 0x18, 0x2B];
-            let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
+            let map: Result<HeaderMap, _> = crate::cbor::from_slice(&test);
             assert!(map.is_err());
 
             // {1: 42, 2: 42, 2: 42}
             let test = [0xa3, 0x01, 0x18, 0x2A, 0x02, 0x18, 0x2A, 0x02, 0x18, 0x2A];
-            let map: Result<HeaderMap, _> = serde_cbor::from_slice(&test);
+            let map: Result<HeaderMap, _> = crate::cbor::from_slice(&test);
             assert!(map.is_err());
         }
 
@@ -811,7 +784,7 @@ mod tests {
         fn cose_sign1_ec256_text() {
             let (ec_private, ec_public) = generate_ec256_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
@@ -822,7 +795,7 @@ mod tests {
             );
             assert!(!cose_doc2.get_unprotected().is_empty(),);
             assert_eq!(
-                cose_doc2.get_unprotected().get(&CborValue::Integer(4)),
+                cose_doc2.get_unprotected().get(&CborValue::Integer(Integer::from(4_i32))),
                 Some(&CborValue::Bytes(b"11".to_vec())),
             );
         }
@@ -831,7 +804,7 @@ mod tests {
         fn cose_sign1_ec256_text_tagged() {
             let (ec_private, ec_public) = generate_ec256_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
@@ -851,13 +824,13 @@ mod tests {
         fn cose_sign1_ec256_text_tagged_serde() {
             let (ec_private, ec_public) = generate_ec256_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
             // Tag 6.18 should be present
             assert_eq!(tagged_bytes[0], 6 << 5 | 18);
-            let cose_doc2: CoseSign1 = serde_cbor::from_slice(&tagged_bytes).unwrap();
+            let cose_doc2 = CoseSign1::from_bytes(&tagged_bytes).unwrap();
 
             assert_eq!(
                 cose_doc1.get_payload::<Openssl>(None).unwrap(),
@@ -871,13 +844,13 @@ mod tests {
 
             let mut protected = HeaderMap::new();
             protected.insert(
-                CborValue::Integer(1),
+                CborValue::Integer(Integer::from(1_i32)),
                 (SignatureAlgorithm::ES256 as i8).into(),
             );
-            protected.insert(CborValue::Integer(15), CborValue::Bytes(b"12".to_vec()));
+            protected.insert(CborValue::Integer(Integer::from(15_i32)), CborValue::Bytes(b"12".to_vec()));
 
             let mut unprotected = HeaderMap::new();
-            unprotected.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            unprotected.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new_with_protected::<Openssl>(
                 TEXT,
@@ -893,11 +866,11 @@ mod tests {
                 .unwrap();
 
             assert_eq!(
-                protected.get(&CborValue::Integer(1)),
-                Some(&CborValue::Integer(-7)),
+                protected.get(&CborValue::Integer(Integer::from(1_i32))),
+                Some(&CborValue::Integer(Integer::from(-7_i32))),
             );
             assert_eq!(
-                protected.get(&CborValue::Integer(15)),
+                protected.get(&CborValue::Integer(Integer::from(15_i32))),
                 Some(&CborValue::Bytes(b"12".to_vec())),
             );
             assert_eq!(payload, TEXT,);
@@ -907,7 +880,7 @@ mod tests {
         fn cose_sign1_ec384_text() {
             let (ec_private, ec_public) = generate_ec384_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
@@ -922,7 +895,7 @@ mod tests {
         fn cose_sign1_ec512_text() {
             let (ec_private, ec_public) = generate_ec512_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
             let cose_doc2 = CoseSign1::from_bytes(&cose_doc1.as_bytes(false).unwrap()).unwrap();
@@ -952,7 +925,7 @@ mod tests {
             let (ec_private, ec_public) = generate_ec512_test_key();
             let (_, ec_public_other) = generate_ec512_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
 
@@ -967,7 +940,7 @@ mod tests {
             let (ec_private, ec_public) = generate_ec512_test_key();
             let (_, ec_public_other) = generate_ec384_test_key();
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
 
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &ec_private).unwrap();
 
@@ -1220,7 +1193,7 @@ mod tests {
             let mut tpm_key = TpmKey::new(tpm_context, prim_key).expect("Error creating TpmKey");
 
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
             let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &mut tpm_key).unwrap();
             let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
 
@@ -1283,7 +1256,7 @@ mod tests {
             let mut tpm_key = TpmKey::new(tpm_context, prim_key).expect("Error creating TpmKey");
 
             let mut map = HeaderMap::new();
-            map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+            map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
             let mut cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &mut tpm_key).unwrap();
 
             // Mangle the signature
@@ -1332,7 +1305,7 @@ mod tests {
                     KmsKey::new(kms_client, key_id, sig_alg).expect("Error building kms_key");
 
                 let mut map = HeaderMap::new();
-                map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+                map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
                 let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &kms_key).unwrap();
                 let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
 
@@ -1365,7 +1338,7 @@ mod tests {
                     KmsKey::new(kms_client, key_id, sig_alg).expect("Error building kms_key");
 
                 let mut map = HeaderMap::new();
-                map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+                map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
                 let mut cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &kms_key).unwrap();
 
                 // Mangle the signature
@@ -1399,7 +1372,7 @@ mod tests {
                     .expect("Error building kms_key");
 
                 let mut map = HeaderMap::new();
-                map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+                map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
                 let cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &kms_key).unwrap();
                 let tagged_bytes = cose_doc1.as_bytes(true).unwrap();
 
@@ -1429,7 +1402,7 @@ mod tests {
                     .expect("Error building kms_key");
 
                 let mut map = HeaderMap::new();
-                map.insert(CborValue::Integer(4), CborValue::Bytes(b"11".to_vec()));
+                map.insert(CborValue::Integer(Integer::from(4_i32)), CborValue::Bytes(b"11".to_vec()));
                 let mut cose_doc1 = CoseSign1::new::<Openssl>(TEXT, &map, &kms_key).unwrap();
 
                 // Mangle the signature


### PR DESCRIPTION
- Replace `serde_cbor` with `ciborium` 0.2 for more active maintenance
- Add cbor module with wrapper functions for serialization/deserialization
- Update all call sites to use new ciborium API
- Update Rust edition to 2021 and bump minimum Rust version to 1.91.1
- Update dependency versions to remove version caps

---

Fixes
- #94
- #119 